### PR TITLE
Add missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ zplug "b4b4r07/hello_bitbucket", \
 
 # Group dependencies. Load emoji-cli if jq is installed in this example
 zplug "stedolan/jq", \
-    from:gh-r \
+    from:gh-r, \
     as:command, \
     rename-to:jq
 zplug "b4b4r07/emoji-cli", \


### PR DESCRIPTION
Missing comma causes error:

```
[zplug] ERROR: from tag must be [github, bitbucket, gh-r, gist, local, oh-my-zsh] (stedolan/jq)
[zplug] ERROR: from tag must be [github, bitbucket, gh-r, gist, local, oh-my-zsh] (stedolan/jq)
__zplug::core::core::is_handler_defined:6: 2: parameter not set
```