### PR TITLE
Add the mechanism to detect mawk

### DIFF
--- a/autoload/init.zsh
+++ b/autoload/init.zsh
@@ -13,16 +13,28 @@ __import "zplug/external"
 __import "core/core"
 __import "job/notify"
 __import "print/print"
+__import "core/awk"
 
 if ! __zplug::core::core::zsh_version 4.3.9; then
-    __zplug::print::print::die "[zplug] zplug does not work this version of zsh $ZSH_VERSION.\n"
-    __zplug::print::print::die "        You must use zsh 4.3.9 or later.\n"
+    __zplug::print::print::die \
+        "[zplug] zplug does not work this version of zsh $ZSH_VERSION.\n"
+    __zplug::print::print::die \
+        "        You must use zsh 4.3.9 or later.\n"
     return 1
 fi
 
 if (( ! $+commands[git] )); then
-    __zplug::print::print::die "[zplug] git command not found in \$PATH\n"
-    __zplug::print::print::die "        zplug depends on git 1.7 or later.\n"
+    __zplug::print::print::die \
+        "[zplug] git command not found\n"
+    __zplug::print::print::die \
+        "        zplug depends on git 1.7 or later.\n"
+    return 1
+fi
+
+# Detect awk variant
+if ! has_awk &>/dev/null; then
+    __zplug::print::print::die \
+        "[zplug] mawk found only. zplug require (n)awk or gawk\n"
     return 1
 fi
 

--- a/base/core/awk.zsh
+++ b/base/core/awk.zsh
@@ -1,0 +1,54 @@
+#!/bin/zsh
+
+__import "print/print"
+
+has_awk() {
+    local    p awk_path awk_variant
+    local -a all_awk
+
+    # Look up all awk from PATH
+    for p in ${^path[@]}/{g,n,m,}awk
+    do
+        if [[ -x $p ]]; then
+            all_awk+=("$p")
+        fi
+    done
+
+    # There is no awk execute file in PATH
+    if (( $#all_awk == 0 )); then
+        __zplug::print::print::die \
+            "[zplug] has_awk(): cannot find awk\n"
+        return 1
+    fi
+
+    # Detect awk variant from available awk list
+    for p in "${all_awk[@]}"
+    do
+        if $p --version 2>&1 | grep -q "GNU Awk"; then
+            # GNU Awk
+            awk_path="$p"
+            awk_variant="gawk"
+            # Use gawk if it's already installed
+            break
+        elif $p -Wv 2>&1 | grep -q "mawk"; then
+            # mawk
+            awk_variant="mawk"
+        else
+            # nawk
+            awk_path="$p"
+            awk_variant="nawk"
+            # Search another variant if awk is nawk
+            continue
+        fi
+    done
+
+    # If only mawk is installed
+    if [[ $awk_variant == "mawk" ]]; then
+        __zplug::print::print::die \
+            "[zplug] your machine has only $awk_variant. zplug require nawk or more\n"
+        return 1
+    else
+        __zplug::print::print::put \
+            "$awk_path\n"
+    fi
+}


### PR DESCRIPTION
- Add `base/core/awk.zsh`
- Modify `autoload/init.zsh`

TODO:

- If mawk is only found, we might want to follow the v1 way that doesn't use awk in stead of logging an error message.
- Add tests