### PR TITLE
Added ZSH_CACHE_DIR variable for oh-my-zsh

### DIFF
--- a/base/sources/oh-my-zsh.zsh
+++ b/base/sources/oh-my-zsh.zsh
@@ -51,6 +51,7 @@ __zplug::oh-my-zsh::load_plugin() {
     # Check if omz is loaded and set some necessary settings
     if [[ -z $ZSH ]]; then
         export ZSH="$ZPLUG_REPOS/$_ZPLUG_OHMYZSH"
+	export ZSH_CACHE_DIR="$ZSH/cache/"
         # Insert to the top of load_plugins
         # load_plugins=(
         #     "$ZSH/oh-my-zsh.sh"

--- a/base/sources/oh-my-zsh.zsh
+++ b/base/sources/oh-my-zsh.zsh
@@ -51,7 +51,7 @@ __zplug::oh-my-zsh::load_plugin() {
     # Check if omz is loaded and set some necessary settings
     if [[ -z $ZSH ]]; then
         export ZSH="$ZPLUG_REPOS/$_ZPLUG_OHMYZSH"
-	export ZSH_CACHE_DIR="$ZSH/cache/"
+        export ZSH_CACHE_DIR="$ZSH/cache/"
         # Insert to the top of load_plugins
         # load_plugins=(
         #     "$ZSH/oh-my-zsh.sh"


### PR DESCRIPTION
As discussed in https://github.com/zplug/zplug/issues/190 this adds the ZSH_CACHE_DIR variable which is used by a number of oh-my-zsh plugins (like the value of cache-path in completion.zsh)