### PR TITLE
Remove zcompdump files on zplug clear

### DIFF
--- a/autoload/commands/__clear__
+++ b/autoload/commands/__clear__
@@ -16,4 +16,4 @@ do
     shift
 done
 
-rm -f "$ZPLUG_CACHE_FILE"
+rm -f "$ZPLUG_CACHE_FILE" "$ZPLUG_HOME/zcompdump" "$ZPLUG_HOME/zcompdump.zwc"


### PR DESCRIPTION
These files are stale anyway, and I can see them theoretically causing issues even if the first load will recreate them