### PR TITLE
Fix locale-specific warning #202

### DIFF
--- a/base/print/print.zsh
+++ b/base/print/print.zsh
@@ -1,9 +1,9 @@
 #!/usr/bin/env zsh
 
 __zplug::print::print::put() {
-    command printf -- "$@"
+    LC_ALL=POSIX command printf -- "$@"
 }
 
 __zplug::print::print::die() {
-    command printf -- "$@" >&2
+    LC_ALL=POSIX command printf -- "$@" >&2
 }


### PR DESCRIPTION
Fix #202 

I have added `LC_ALL=POSIX` to the beginning of `printf` command to solve locale-specific waring.  I will merge this P-R as soon as I can confirm my solution in #202 issue.