### PR TITLE
Do a deep clone if the 'at' tag is used

### DIFF
--- a/autoload/utils/__clone__
+++ b/autoload/utils/__clone__
@@ -59,6 +59,10 @@ do
     shift
 done
 
+# If an 'at' tag has been specified, do a deep clone to allow any commit to be
+# checked out.
+[[ -n "$tag_at" ]] && depth_option=""
+
 # Initialize
 {
     [[ -d $ZPLUG_REPOS ]] || mkdir -p "$ZPLUG_REPOS"


### PR DESCRIPTION
The depth tag can conflict with the at tag. A shallow clone may not include the commit/branch/tag specified with the at tag. To avoid confusing users, this PR ignores the depth - forcing a deep clone - when the at tag is used.

## Steps to reproduce
To reproduce this issue, specify a shallow clone and an use the at tag with a commit/branch/tag that is not included in the shallow clone. You will get an error `zplug install`. For instance:
```
export ZPLUG_CLONE_DEPTH=1  # Shallow clone for other plugins.
zplug "shvenkat/oh-my-zsh", at:"plugin/shrink-path", use:"plugins/shrink-path/*.zsh"
zplug check || zplug install
zplug load
```