### PR TITLE
Do not add to path if ZPLUG_{ROOT,HOME} are empty

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -98,8 +98,8 @@ __zplug::core::core::prepare()
 
     # Add to the PATH
     path=(
-    "$ZPLUG_ROOT"/bin
-    "$ZPLUG_HOME"/bin
+    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
+    ${ZPLUG_HOME:+"$ZPLUG_HOME/bin"}
     "$path[@]"
     )
 


### PR DESCRIPTION
DEMO code

```zsh
#!/bin/zsh

unset ZPLUG_ROOT ZPLUG_HOME

path=(
"$ZPLUG_ROOT"/bin
"$ZPLUG_HOME"/bin
"$path[@]"
)
```

Run this script...:

```console
$ zsh a.zsh
/bin
/bin
...
...
```