### PR TITLE
Redirect output to >&2 instead of /dev/stderr

### DIFF
--- a/base/job/spinner.zsh
+++ b/base/job/spinner.zsh
@@ -37,7 +37,7 @@ __zplug::job::spinner::spin()
         do
             __zplug::job::spinner::is_spin || break
 
-            printf " $spinner\r" >/dev/stderr
+            printf " $spinner\r" >&2
             sleep "$latency"
         done
     done


### PR DESCRIPTION
With `/dev/stderr`, this fails terribly under sudo, because `/dev/stderr` continues to point to the previous user's fd and the current user likely doesn't have permissions on it. 

So sudo'ing to a user with zplug setup to run, streams errors:

```
__zplug::job::spinner::spin:16: permission denied: /dev/stderr
```