### PR TITLE
Evaluate IF tag and bypass check if conditions are not met

### DIFF
--- a/autoload/commands/__check__
+++ b/autoload/commands/__check__
@@ -38,6 +38,20 @@ fi
 
 for repo in "${repos[@]}"
 do
+    # Evaluate IF tag and bypass existance check if conditions are not met
+    tags[if]="$(
+    __zplug::core::core::run_interfaces \
+        'if' \
+        "$repo" \
+        2> >(__zplug::io::log::capture)
+    )"
+    if [[ -n $tags[if] ]]; then
+        if ! eval "$tags[if]" 2> >(__zplug::io::log::capture) >/dev/null; then
+            $is_verbose && __zplug::io::print::die "$repo: (bypassed check)\n"
+            continue
+        fi
+    fi
+
     tags[from]="$(
     __zplug::core::core::run_interfaces \
         'from' \


### PR DESCRIPTION
Fix #235. For example if a package has:

```
zplug 'foo/bar', if:false
```

the check should be ignored and `zplug check` should return 0.

## `.zshrc` to reproduce problem

```
export ZPLUG_LOADFILE=
export ZPLUG_USE_CACHE=false

source ~/.zplug/init.zsh

zplug "geekjuice/flat-ui-mintty", use:flat-mintty, if:"[[ $OSTYPE == *cygwin* ]]"

zplug check --verbose
echo "Status: $status"
```

## Output before patch:

```
- geekjuice/flat-ui-mintty: not installed
Status: 1
NigoroMac%
```

## Output after patch (as expected):

```
geekjuice/flat-ui-mintty: (bypassed check)
Status: 0
NigoroMac%
```