### PR TITLE
Fix wrong condition for prompt_subst

### DIFF
--- a/base/io/cache.zsh
+++ b/base/io/cache.zsh
@@ -74,7 +74,7 @@ __zplug::io::cache::update()
         __zplug::io::print::put 'if $is_verbose; then\n'
         __zplug::io::print::put '  echo "Static loading..." >&2\n'
         __zplug::io::print::put 'fi\n'
-        if [[ -o prompt_subst ]]; then
+        if [[ ! -o prompt_subst ]]; then
             __zplug::io::print::put '\nsetopt prompt_subst\n'
         fi
         __zplug::io::print::put '\n'


### PR DESCRIPTION
The original code put `setopt prompt_subst` only when `prompt_subst` is on. I believe this is a bug because `setopt prompt_subst` is not needed when `prompt_subst` is already turned on.