### PR TITLE
Don't nuke $PATH in cachefile

### DIFF
--- a/base/io/cache.zsh
+++ b/base/io/cache.zsh
@@ -103,7 +103,7 @@ __zplug::io::cache::update()
             __zplug::io::print::put ')\n'
         fi
         __zplug::io::print::put '\n# path\n'
-        __zplug::io::print::put 'typeset -U path\n\n'
+        __zplug::io::print::put 'typeset -gx -U path\n\n'
         __zplug::io::print::put '\ncompinit -C -d %s\n\n' "$ZPLUG_HOME/zcompdump"
         if (( $#nice_plugins > 0 )); then
             __zplug::io::print::put '# Loading after compinit\n'


### PR DESCRIPTION
The `typeset -U path` call in the zplug cache [wipes out the local $PATH](1). The `-gx` options to `typeset` should ensure that the global $PATH variable is still available to functions nice'd >= 10.

[1]: http://www.verycomputer.com/177_fb5233146f3d0cd0_1.htm

### System Information

* `uname -a`


* `zsh --version`
```
zsh 5.2 (x86_64-apple-darwin15.0.0)
```

* zplug version: 2.2.1

### Minimal zshrc

Run twice (once to generate the cache, a second time to use the cachefile).

```zsh
source "$ZPLUG_HOME"/init.zsh
zplug "zsh-users/zsh-completions", nice:11                                                                                                                                      zplug check || zplug install
zplug load --verbose
```

### Result

```bash
Static loading...

/Users/Josh/.local/share/zplug/repos/zsh-users/zsh-completions/zsh-completions.plugin.zsh:1: command not found: dirname
```