### PR TITLE
Optimize startup time

### DIFF
--- a/autoload/init.zsh
+++ b/autoload/init.zsh
@@ -7,6 +7,7 @@ fpath=(
 "$fpath[@]"
 )
 
+autoload -Uz regexp-replace
 autoload -Uz add-zsh-hook
 autoload -Uz colors
 autoload -Uz compinit

--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -41,14 +41,17 @@ __zplug::core::core::get_interfaces()
             if $is_prefix; then
                 name="__${name}__"
             fi
-            cat "$interface" \
-                | awk '
-                $0 ~ "# Description:" {
-                    getline
-                    sub(/^# */, "")
-                    print $0
-                }' \
-                | read desc
+
+            desc=""
+            while IFS= read -r line
+            do
+                if [[ "$line" =~ "# Description:" ]]; then
+                    IFS= read -r desc
+                    regexp-replace desc "^# *" ""
+                    break
+                fi
+            done < "$interface"
+
             interfaces[$name]="$desc"
         done
 


### PR DESCRIPTION
See #257 and #258 for background.

I see a huge improvement in startup time, from >200ms to ~80ms, matching with zgen's startup time if zgen itself is sourced.

Comparison:
zgen(load cache file only): 40ms
zgen(load cache file and source zgen.zsh): 80ms
zplug(with this patch): 80ms
zplug(without this patch): 200ms
