### PR TITLE
docs: typo fix - replace 'birary' with 'binary'

### DIFF
--- a/doc/man/man1/zplug.1
+++ b/doc/man/man1/zplug.1
@@ -99,7 +99,7 @@ plugins/themes
 .sp -1
 .IP \(bu 2.3
 .\}
-Birary artifacts on
+Binary artifacts on
 GitHub Releases
 .RE
 .sp

--- a/doc/txt/zplug.txt
+++ b/doc/txt/zplug.txt
@@ -31,7 +31,7 @@ It's such a fantabulous piece of software.
 **  Gist file (https://gist.github.com[gist.github.com])
 **  Third-party sources e.g., https://github.com/robbyrussell/oh-my-zsh[oh-my-zsh]
     plugins/themes
-**  Birary artifacts on https://help.github.com/articles/about-releases[GitHub Releases]
+**  Binary artifacts on https://help.github.com/articles/about-releases[GitHub Releases]
 **  Local plugins
 **  etc. (you can add your own sources!)
 *   Super-fast parallel installation/update

--- a/doc/zplug.txt
+++ b/doc/zplug.txt
@@ -32,7 +32,7 @@ It's such a fantabulous piece of software.
 **  Third-party sources e.g.,
  https://github.com/robbyrussell/oh-my-zsh[oh-my-zsh] and
  https://github.com/sorin-ionescu/prezto[prezto] plugins/themes
-**  Birary artifacts on https://help.github.com/articles/about-releases[GitHub Releases]
+**  Binary artifacts on https://help.github.com/articles/about-releases[GitHub Releases]
 **  Local plugins
 **  etc. (you can add your own sources!)
 *   Super-fast parallel installation/update


### PR DESCRIPTION
Small typo fix in docs / man pages.