### PR TITLE
Allow Gitlab.com repositories as a source

### DIFF
--- a/base/sources/gitlab.zsh
+++ b/base/sources/gitlab.zsh
@@ -1,0 +1,42 @@
+__zplug::sources::gitlab::check()
+{
+    __zplug::sources::github::check "$argv[@]"
+}
+
+__zplug::sources::gitlab::install()
+{
+    __zplug::sources::github::install "$argv[@]"
+}
+
+__zplug::sources::gitlab::update()
+{
+    __zplug::sources::github::update "$argv[@]"
+}
+
+__zplug::sources::gitlab::get_url()
+{
+    local repo="$1" url_format
+
+    case "$ZPLUG_PROTOCOL" in
+        HTTPS | https)
+            # https://git::@gitlab.com/%s.git
+            url_format="https://git::@gitlab.com/${repo}.git"
+            ;;
+        SSH | ssh)
+            # git@gitlab.com:%s.git
+            url_format="git@gitlab.com:${repo}.git"
+            ;;
+    esac
+
+    echo "$url_format"
+}
+
+__zplug::sources::gitlab::load_plugin()
+{
+    __zplug::sources::github::load_plugin "$argv[@]"
+}
+
+__zplug::sources::gitlab::load_command()
+{
+    __zplug::sources::github::load_command "$argv[@]"
+}


### PR DESCRIPTION
Lets people use plugins from Gitlab the same way as Github/Bitbucket
