### PR TITLE
Fix git_prompt_info

### DIFF
--- a/base/utils/theme.zsh
+++ b/base/utils/theme.zsh
@@ -5,9 +5,9 @@
 git_prompt_info()
 {
     local ref hide_status
-    hide_status="$(git config --get oh-my-zsh.hide-status)"
+    hide_status="$(git config --get oh-my-zsh.hide-status 2>/dev/null)"
     if [[ $hide_status != 1 ]]; then
-        ref="$(git symbolic-ref HEAD)" || ref="$(git rev-parse --short HEAD)" || return 0
+        ref="$(git symbolic-ref HEAD 2>/dev/null)" || ref="$(git rev-parse --short HEAD 2>/dev/null)" || return 0
         echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
     fi
 }

--- a/base/utils/theme.zsh
+++ b/base/utils/theme.zsh
@@ -6,7 +6,7 @@ git_prompt_info()
 {
     local ref hide_status
     hide_status="$(git config --get oh-my-zsh.hide-status)"
-    if [[ -n $hide_status ]] && [[ $hide_status != 1 ]]; then
+    if [[ $hide_status != 1 ]]; then
         ref="$(git symbolic-ref HEAD)" || ref="$(git rev-parse --short HEAD)" || return 0
         echo "$ZSH_THEME_GIT_PROMPT_PREFIX${ref#refs/heads/}$(parse_git_dirty)$ZSH_THEME_GIT_PROMPT_SUFFIX"
     fi


### PR DESCRIPTION
Hello.

commit e4d0570eab12de873fcf0ae28fb60919ceafd136 make `git_prompt_info` do nothing without git config oh-my-zsh.hide-status.
But it's different from [oh-my-zsh `git_prompt_info` ](https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/git.zsh).

Then, suppress "not a git repository" message by using 2>/dev/null` like oh-my-zsh's it.

minimum zshrc
```zsh
# minimum zshrc
source ~/.zplug/init.zsh
zplug "b4b4r07/zplug"
#zplug "ywatase/zplug", at:fix_git_prompt_info
zplug check || zplug install

zplug load --verbose

setopt prompt_subst
_get_prompt () {
        echo "%~ ${$(git_prompt_info)} \$ "
}
PROMPT='${$(_get_prompt)}'
```

and 

```
cd ~/.zplug/repos/b4b4r07/zplug
```
but don't show `master`

use 
```
zplug "ywatase/zplug", at:fix_git_prompt_info
```

and 

```
cd ~/.zplug/repos/b4b4r07/zplug
```

then show `master`

```
$ uname -a
Linux beagle 3.16.0-4-amd64 #1 SMP Debian 3.16.36-1+deb8u2 (2016-10-19) x86_64 GNU/Linux

$ zsh --version
zsh 5.0.7 (x86_64-pc-linux-gnu)
```