### PR TITLE
json_escape() compatible with python 2 and 3

### DIFF
--- a/base/utils/shell.zsh
+++ b/base/utils/shell.zsh
@@ -207,7 +207,7 @@ __zplug::utils::shell::eval()
 __zplug::utils::shell::json_escape()
 {
     if (( $+commands[python] )); then
-        python -c 'import json,sys; print json.dumps(sys.stdin.read())'
+        python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
     else
         echo "(Not available: python requires)"
     fi


### PR DESCRIPTION
On Arch Linux python3 is the system's default.
In python3 `print` is a function and not a statement.
So on the first lauch of zsh after login it prints the following error in console:
```
File "<string>", line 1
import json,sys; print json.dumps(sys.stdin.read())
                       ^
SyntaxError: invalid syntax
```
The proposed workaround is to change in `__zplug::utils::shell::json_escape()` `print` to `print()`.
In python2 it works as expected with a single argument (see [this answer](http://stackoverflow.com/a/12162754)).