### PR TITLE
Add gitlab support

### DIFF
--- a/base/sources/gitlab.zsh
+++ b/base/sources/gitlab.zsh
@@ -1,0 +1,47 @@
+__zplug::sources::gitlab::check()
+{
+    __zplug::sources::github::check "$argv[@]"
+}
+
+__zplug::sources::gitlab::install()
+{
+    __zplug::sources::github::install "$argv[@]"
+}
+
+__zplug::sources::gitlab::update()
+{
+    __zplug::sources::github::update "$argv[@]"
+}
+
+__zplug::sources::gitlab::get_url()
+{
+    local repo="$1" url_format
+
+    case "$ZPLUG_PROTOCOL" in
+        HTTPS | https)
+            # https://git::@gitlab.com/%s.git
+            url_format="https://git::@gitlab.com/${repo}.git"
+            ;;
+        SSH | ssh)
+            # git@gitlab.com:%s.git
+            url_format="git@gitlab.com:${repo}.git"
+            ;;
+    esac
+
+    echo "$url_format"
+}
+
+__zplug::sources::gitlab::load_plugin()
+{
+    __zplug::sources::github::load_plugin "$argv[@]"
+}
+
+__zplug::sources::gitlab::load_command()
+{
+    __zplug::sources::github::load_command "$argv[@]"
+}
+
+__zplug::sources::gitlab::load_theme()
+{
+    __zplug::sources::github::load_theme "$argv[@]"
+}

--- a/doc/guide/External-Sources.md
+++ b/doc/guide/External-Sources.md
@@ -4,6 +4,7 @@ If there is a service/framework you want to install from that's not supported
 by zplug (yet!), you can add your own. We call these "sources."
 [GitHub](https://github.com), [Bitbucket](https://bitbucket.org), [GitHub
 Gist](https://gist.github.com), GitHub releases,
+[Gitlab](https://gitlab.com),
 [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), and
 [prezto](https://github.com/sorin-ionescu/prezto) are supported by default.
 Sources are what you specify with the `from` tag (e.g. `from:bitbucket`), so

--- a/doc/man/man1/zplug.1
+++ b/doc/man/man1/zplug.1
@@ -53,7 +53,8 @@ Can manage everything
 .IP \(bu 2.3
 .\}
 Zsh plugins/UNIX commands on
-GitHub
+GitHub,
+Gitlab
 and
 Bitbucket
 .RE
@@ -380,7 +381,7 @@ T}:T{
 Specify the service from which you install
 T}:T{
 .sp
-github,bitbucket,gh\-r,gist, oh\-my\-zsh,prezto,local (github)
+github,gitlab,bitbucket,gh\-r,gist, oh\-my\-zsh,prezto,local (github)
 T}:T{
 .sp
 from:gh\-r
@@ -763,6 +764,11 @@ zplug "b4b4r07/hello_bitbucket", \e
     from:bitbucket, \e
     hook\-build:"chmod 755 *\&.sh", \e
     use:"*\&.sh"
+
+# Support Gitlab
+zplug "willemmali-sh/chegit", \e
+    as:command, \e
+    from:gitlab
 
 # Group dependencies, emoji\-cli depends on jq in this example
 zplug "stedolan/jq", \e

--- a/doc/man/man5/zplug-from.5
+++ b/doc/man/man5/zplug-from.5
@@ -50,7 +50,7 @@ T}
 lt lt.
 T{
 .sp
-github, bitbucket, gh\-r, gist, oh\-my\-zsh, local
+github, gitlab, bitbucket, gh\-r, gist, oh\-my\-zsh, local
 T}:T{
 .sp
 github

--- a/doc/txt/zplug-from.txt
+++ b/doc/txt/zplug-from.txt
@@ -23,10 +23,10 @@ will be installed as the plugin or as the command.
 
 .zplug from tag
 [options="header"]
-|================================================================
-| Possive Values                                  | Default value
-| github, bitbucket, gh-r, gist, oh-my-zsh, local | github
-|================================================================
+|=========================================================================
+| Possive Values                                          | Default value
+| github, gitlab, bitbucket, gh-r, gist, oh-my-zsh, local | github
+|=========================================================================
 
 Besides, by using `zstyle` command, you can change default value:
 

--- a/doc/zplug.txt
+++ b/doc/zplug.txt
@@ -26,7 +26,7 @@ Unlike antigen, zplug requires no ZSH plugin file (`*.plugin.zsh`).
 It's such a fantabulous piece of software.
 
 *   Can manage everything
-**  Zsh plugins/UNIX commands on https://github.com[GitHub]
+**  Zsh plugins/UNIX commands on https://github.com[GitHub], https://gitlab.com[Gitlab],
     and https://bitbucket.org[Bitbucket]
 **  Gist file (https://gist.github.com[gist.github.com])
 **  Third-party sources e.g.,
@@ -123,7 +123,7 @@ and so on. If you want to use extended glob, see later section for setting the z
 `use:"*darwin*"`
 
 |*from* | Specify the service from which you install
-| `github`,`bitbucket`,`gh-r`,`gist`,
+| `github`, `gitlab`,`bitbucket`,`gh-r`,`gist`,
 `oh-my-zsh`,`prezto`,`local` (`github`) | `from:gh-r`
 
 |*at* | Branch, tag, or commit to use | *revision* (`master`) | `at:v1.5.6`
@@ -337,6 +337,11 @@ zplug "b4b4r07/hello_bitbucket", \
     from:bitbucket, \
     hook-build:"chmod 755 *.sh", \
     use:"*.sh"
+
+# Support Gitlab
+zplug "willemmali-sh/chegit", \
+    as:command, \
+    from:gitlab
 
 # Group dependencies, emoji-cli depends on jq in this example
 zplug "stedolan/jq", \

--- a/misc/completions/_zplug
+++ b/misc/completions/_zplug
@@ -102,7 +102,7 @@ case "$words[1]" in
         _values -S : -s , "zplug tags" \
             "as[Specify whether to register as commands or to register as plugins]:as:(plugin command)" \
             "use[Specify the pattern to source (for plugin) or relative path to export (for command)]:use:->use" \
-            "from[Specify the services you use to install]:from:(gh-r gist oh-my-zsh github bitbucket local)" \
+            "from[Specify the services you use to install]:from:(gh-r gist oh-my-zsh github bitbucket gitlab local)" \
             "at[Support branch/tag installation]:at:" \
             "rename-to[Specify filename you want to rename]:rename-to:" \
             "dir[Installation directory (RO)]:dir:->dir" \


### PR DESCRIPTION
Pretty much a clone of bitbucket.zsh.

misc/completions/_zplug could be altered to look in base/sources/ for 'zplug from tags'