### PR TITLE
Add some new options to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Finally, use `zplug install` to install your plugins and reload `.zshrc`.
 |-----------|-------------|---------|
 | `install` | Install packages in parallel | (None) |
 | `load`    | Source installed plugins and add installed commands to `$PATH` | `--verbose` |
-| `list`    | List installed packages (more specifically, view the associative array `$zplugs`) | `--select` |
+| `list`    | List installed packages (more specifically, view the associative array `$zplugs`) | `--select`,`--installed`,`--loaded` |
 | `update`  | Update installed packages in parallel | `--select`,`--force` |
 | `check`   | Return true if all packages are installed, false otherwise | `--verbose` |
 | `status`  | Check if the remote repositories are up to date | `--select` |

--- a/autoload/commands/__list__
+++ b/autoload/commands/__list__
@@ -2,11 +2,11 @@
 # Description:
 #   List installed packages (more specifically, view the associative array $zplugs)
 
-local    arg filter repo tag
-local    is_select=false
-local -i ret=0
-local -a repos similar_repos
-local -A copy_zplugs
+local     arg repo tag filter
+local     is_loaded=false is_installed=false is_select=false
+local -aU repos
+
+tag="${(kj:|:)_zplug_tags[@]}"
 
 while (( $# > 0 ))
 do
@@ -14,6 +14,12 @@ do
     case "$arg" in
         --select)
             is_select=true
+            ;;
+        --loaded)
+            is_loaded=true
+            ;;
+        --installed)
+            is_installed=true
             ;;
         -*|--*)
             __zplug::core::options::unknown "$arg"
@@ -24,106 +30,63 @@ do
             return 1
             ;;
         */*)
-            # Do not remove the end of the at sign
-            # At the end of the treatment,
-            # get rid of those at displaying to stdout
-            repos+=( "$arg" )
+            # Do nothing
             ;;
         *)
-            return 1
+            # Do nothing
             ;;
     esac
     shift
 done
 
-# Initialize
-{
-    # If assosiate array "zplugs" is empty,
-    # it means there are no packages that are managed by zplug
-    if (( $#zplugs == 0 )); then
-        __zplug::io::print::f \
-            --die \
-            --zplug \
-            --func \
-            "no package managed by zplug\n"
-        return 1
-    fi
-
-    if $is_select; then
-        __zplug::utils::shell::search_commands "$ZPLUG_FILTER" \
-            | read filter
-        if [[ -z $filter ]]; then
-            __zplug::io::print::die \
-                --die \
-                --zplug \
-                --error \
-                "There is no available filter in ZPLUG_FILTER\n"
-            return 1
-        fi
-        repos=( ${(@f)"$(echo "${(Fk)zplugs[@]}" | eval "$filter")"} )
-
-        # There is no package selected by the filter
-        if (( $#repos == 0 )); then
-            return 0
-        fi
-    fi
-}
-
-if (( $#repos > 0 )); then
-    copy_zplugs=()
-    for repo in "${repos[@]}"
-    do
-        if __zplug::base::base::zpluged "$repo"; then
-            # TODO:
-            # @ (at-sign)
-            # e.g. zplug list b4b4r07/enhancd
-            # -> b4b4r07/enhancd
-            # -> b4b4r07/enhancd (b4b4r07/enhancd@)
-
-            # It's already managed
-            copy_zplugs+=(
-            "$repo"
-            "${zplugs[$repo]}"
-            )
-        else
-            # It doesn't managed yet
-            # Try to search the package with fuzzy match
-            similar_repos=( ${(@f)"$(awk -v repo=$repo '$1 ~ repo' <<<${(Fk)zplugs[@]})"} )
-            # There is even no similar package
-            if (( $#similar_repos == 0 )); then
-                copy_zplugs+=(
-                "$repo"
-                "NO SUCH PACKAGE"
-                )
-                ret=1
-            fi
-            for repo in "${similar_repos[@]}"
-            do
-                if __zplug::base::base::zpluged "$repo"; then
-                    copy_zplugs+=(
-                    "$repo"
-                    "${zplugs[$repo]}"
-                    )
-                fi
-            done
-        fi
-    done
-else
-    copy_zplugs=( "${(@kv)zplugs[@]}" )
+# If assosiate array "zplugs" is empty,
+# it means there are no packages that are managed by zplug
+if (( $#zplugs == 0 )); then
+    __zplug::io::print::f \
+        --die \
+        --zplug \
+        --func \
+        "no package managed by zplug\n"
+    return 1
 fi
 
-dq='"'
-for copy in "${(k)copy_zplugs[@]}"
-do
-    tag="nil"
-    if [[ -n $copy_zplugs[$copy] ]]; then
-        echo "$copy_zplugs[$copy]" \
-            | sed 's/$/'"$dq"'/g; s/:/:'"$dq"'/g; s/, /'"$dq"', /g;' \
-            | read tag
-    fi
-    printf "%s  =>  %s\n" \
-        "$fg[green]${copy:gs:@::}$reset_color" \
-        "$tag"
-done
+if $is_loaded; then
+    repos=( ${(u@f)"$(<"$_zplug_load_log[success]")"} )
+elif $is_installed; then
+    repos=( "$ZPLUG_REPOS"/*/*(/:gs:"$ZPLUG_REPOS"/:) )
+    repos=( "${repos[@]%/}" )
+else
+    repos=( "${(uk)zplugs[@]:gs:@::}" )
+fi
 
-return $ret
+if $is_select; then
+    __zplug::utils::shell::search_commands \
+        "$ZPLUG_FILTER" \
+        | read filter
+    if [[ -z $filter ]]; then
+        __zplug::io::print::f \
+            --die --zplug \
+            "There is no available filter in ZPLUG_FILTER\n"
+        return 1
+    fi
+    repos=( ${(@f)"$(print -l "$repos[@]" | ${=filter})"} )
+fi
+
+if __zplug::utils::shell::is_atty; then
+    # Disply tag information in color
+    # when connected to the terminal
+    for repo in "$repos[@]"
+    do
+        builtin printf "$fg[green]$repo$reset_color"
+        builtin printf "$fg[blue] => $reset_color"
+        builtin printf "${zplugs[$repo]:-"$fg[red]none"}\n"
+    done \
+        | perl -pe 's/('"$tag"'):/'$fg[yellow]'$1'$reset_color':/g' \
+        | sed -E 's/:/:"/g;s/, /", /g;/none$/!s/$/"/g' # quotes tag
+    printf "$reset_color"
+else
+    # When not connected to the termianl,
+    # e.g. piped with the grep command (`zplug list | grep zsh`)
+    # don't display tag information
+    for repo ("$repos[@]") echo "$repo"
+fi

--- a/autoload/commands/__list__
+++ b/autoload/commands/__list__
@@ -43,16 +43,24 @@ done
 # it means there are no packages that are managed by zplug
 if (( $#zplugs == 0 )); then
     __zplug::io::print::f \
-        --die \
-        --zplug \
-        --func \
+        --die --zplug \
         "no package managed by zplug\n"
     return 1
 fi
 
 if $is_loaded; then
-    repos=( ${(u@f)"$(<"$_zplug_load_log[success]")"} )
+    if [[ -s $_zplug_load_log[success] ]]; then
+        repos=( ${(u@f)"$(<"$_zplug_load_log[success]")"} )
+    else
+        __zplug::io::print::f \
+            --die --zplug \
+            "First, you have to run 'zplug load'\n"
+        __zplug::log::write::info "$_zplug_load_log[success]: not found or empty\n"
+        return 1
+    fi
 elif $is_installed; then
+    # By using a file glob, it's checked whether it really exists
+    # A slash is added to the end, but delete it since it's unnecessary
     repos=( "$ZPLUG_REPOS"/*/*(/:gs:"$ZPLUG_REPOS"/:) )
     repos=( "${repos[@]%/}" )
 else
@@ -90,3 +98,6 @@ else
     # don't display tag information
     for repo ("$repos[@]") echo "$repo"
 fi
+
+# Returns true if a length of repos is greater than zero
+return !$#repos

--- a/autoload/commands/__status__
+++ b/autoload/commands/__status__
@@ -2,7 +2,7 @@
 # Description:
 #   Check if the remote repositories are up to date
 
-local    state arg filter repo
+local    state arg repo
 local -A repo_pids proc_states hook_build hook_finished hook_pids status_codes
 local -A tags
 local -F SECONDS=0

--- a/autoload/commands/__update__
+++ b/autoload/commands/__update__
@@ -3,7 +3,7 @@
 #   Update installed packages in parallel
 
 local     is_force=false
-local     repo arg filter
+local     repo arg
 local -A  repo_pids proc_states hook_build hook_finished hook_pids status_codes
 local -A  tags
 local -F  SECONDS=0

--- a/base/utils/shell.zsh
+++ b/base/utils/shell.zsh
@@ -216,3 +216,14 @@ print(json.dumps(sys.stdin.read()))' \
         echo "(Not available: python requires)"
     fi
 }
+
+__zplug::utils::shell::is_atty()
+{
+    if [[ -t 0 && -t 1 ]]; then
+        # terminal
+        return 0
+    else
+        # pipeline
+        return 1
+    fi
+}

--- a/doc/guide/ja/README.md
+++ b/doc/guide/ja/README.md
@@ -199,7 +199,7 @@ Finally, use `zplug install` to install your plugins and reload `.zshrc`.
 |-----------|-------------|---------|
 | `install` | 並列インストール | (なし) |
 | `load`    | インストール済みプラグインを読み込み、インストール済みコマンドを `$PATH` に追加する | `--verbose` |
-| `list`    | インストール済みパッケージを表示する (端的に連想配列 `$zplugs` を表示する) | `--select` |
+| `list`    | インストール済みパッケージを表示する (端的に連想配列 `$zplugs` を表示する) | `--select`,`--installed`,`--loaded` |
 | `update`  | インストール済みパッケージを並列でアップデートする | `--select`,`--force` |
 | `check`   | 未インストールなパッケージがないなら真を返し、そうでなければ偽を返す | `--verbose` |
 | `status`  | パッケージが最新かどうか確認する| `--select` |

--- a/misc/completions/_zplug
+++ b/misc/completions/_zplug
@@ -75,10 +75,17 @@ case "$words[1]" in
             '(--verbose)--verbose[display loading files]'
         ret=0
         ;;
-    status|list|update)
+    status|update)
         _arguments \
             '(--select)--select[select items with interactive filters]' \
             '*:: :( "${(k)zplugs[@]}" )'
+        ret=0
+        ;;
+    list)
+        _arguments \
+            '(--loaded --installed)--loaded[list loaded packages]' \
+            '(--loaded --installed)--installed[list installed packages]' \
+            '(--select)--select[list packages and select them]'
         ret=0
         ;;
     clean)


### PR DESCRIPTION
- Organize internal specifications
- Add --loaded option to list loaded packages
- Add --installed option to list installed packages

`list` command only lists the contents of $zplugs array.
These options were necessary to list packages such as installed.