### PR TITLE
Fix #348

### DIFF
--- a/base/job/process.zsh
+++ b/base/job/process.zsh
@@ -22,9 +22,9 @@ __zplug::job::process::get_status_code() {
     fi
 
     cat "$_zplug_log[$target]" \
-        | grep "^repo:$repo\t" \
-        | awk '{print $2}' \
-        | cut -d: -f2
+        | __zplug::utils::awk::ltsv \
+        'key("repo")=="'"$repo"'"{print key("status")}'
+
     return $status
 }
 

--- a/base/utils/awk.zsh
+++ b/base/utils/awk.zsh
@@ -64,3 +64,24 @@ __zplug::utils::awk::available()
         return 1
     fi
 }
+
+__zplug::utils::awk::ltsv()
+{
+    local \
+        user_awk_script="$1" \
+        ltsv_awk_script
+
+    ltsv_awk_script=$(cat <<-'EOS'
+    function key(name) {
+        for (i = 1; i <= NF; i++) {
+            match($i, ":");
+            xs[substr($i, 0, RSTART)] = substr($i, RSTART+1);
+        };
+        return xs[name":"];
+    }
+EOS
+    )
+
+    awk -F'\t' \
+        "${ltsv_awk_script} ${user_awk_script}"
+}


### PR DESCRIPTION
This is because grep may not be able to correctly distinguish tab characters.
In order to solve this, added a ltsv parser written by awk.

- Fix #326 (see also second commit in P-R #344), fix #348
- Add `__zplug::utils::awk::ltsv function`