### PR TITLE
Support various file formats with gh-r tag

### DIFF
--- a/autoload/tags/__use__
+++ b/autoload/tags/__use__
@@ -27,18 +27,6 @@ __zplug::core::core::run_interfaces \
     "$arg"
 )"
 
-if [[ $tags[from] == "gh-r" ]]; then
-    default=""
-    if [[ -n $use ]]; then
-        use="$(__zplug::utils::shell::glob2regexp "$use")"
-    else
-        use="$(__zplug::base::base::get_os)"
-        if __zplug::base::base::is_osx; then
-            use="(darwin|osx)"
-        fi
-    fi
-fi
-
 if [[ $tags[as] == "theme" ]]; then
     default=""
 fi

--- a/base/core/cache.zsh
+++ b/base/core/cache.zsh
@@ -48,10 +48,13 @@ __zplug::core::cache::commit()
     defer_2_plugins=( ${(@f)reply_hash[defer_2_plugins]} )
     defer_3_plugins=( ${(@f)reply_hash[defer_3_plugins]} )
     unclassified_plugins=( ${(@f)reply_hash[unclassified_plugins]} )
-    for pair (${(@f)reply_hash[load_commands]}) load_commands+=( ${(@s:\0:)pair} )
+    for pair in ${(@f)reply_hash[load_commands]}
+    do
+        load_commands+=( ${(@s:\0:)pair} ) 2> >(__zplug::log::capture::error) >/dev/null
+    done
     for pair in ${reply_hash[hook_load]}
     do
-        hook="${${(@s:\0:)pair}[2,-1]}"
+        hook="${${(@s:\0:)pair}[2,-1]}" 2> >(__zplug::log::capture::error) >/dev/null
     done
     repo="$reply_hash[repo]"
 

--- a/base/sources/github.zsh
+++ b/base/sources/github.zsh
@@ -241,9 +241,18 @@ __zplug::sources::github::load_command()
                 __zplug::utils::shell::expand_glob "$tags[dir]/$tags[use]" "(N-.)"
             )"} )
         fi
+        if [[ $tags[from] == "gh-r" ]]; then
+            sources=( $tags[dir]/**/*${repo:t}*(N-.) )
+            if (( $#sources == 0 )); then
+                sources+=( $tags[dir]/**/*(N-*) )
+            fi
+        fi
         dst=${${tags[rename-to]:+$ZPLUG_HOME/bin/$tags[rename-to]}:-"$ZPLUG_HOME/bin"}
         for src in "$sources[@]"
         do
+            if [[ ! -f $src ]]; then
+                continue
+            fi
             chmod 755 "$src"
             rename_hash+=("$src" "$dst")
         done

--- a/base/sources/github.zsh
+++ b/base/sources/github.zsh
@@ -237,9 +237,6 @@ __zplug::sources::github::load_command()
                 sources=( "$tags[dir]/${repo:t}"(N-.) )
             fi
         else
-            if [[ $tags[use] == $default_tags[use] || $tags[from] == "gh-r" ]]; then
-                tags[use]="*(N-*)"
-            fi
             sources=( ${(@f)"$( \
                 __zplug::utils::shell::expand_glob "$tags[dir]/$tags[use]" "(N-.)"
             )"} )

--- a/base/utils/releases.zsh
+++ b/base/utils/releases.zsh
@@ -71,27 +71,27 @@ __zplug::utils::releases::get_url()
             "$repo"
         )"
 
-        #if [[ $tags[use] == '*.zsh' ]]; then
-        #    tags[use]=
-        #fi
-        #if [[ $tags[at] == "master" ]]; then
-        #    tags[at]="latest"
-        #fi
+        if [[ $tags[use] == '*.zsh' ]]; then
+            tags[use]=
+        fi
+        if [[ $tags[at] == "master" ]]; then
+            tags[at]="latest"
+        fi
 
-        #if [[ -n $tags[at] && $tags[at != "latest" ]]; then
-        #    tags[at]="tag/$tags[at"
-        #else
-        #    tags[at]="latest"
-        #fi
+        if [[ -n $tags[at] && $tags[at] != "latest" ]]; then
+            tags[at]="tag/$tags[at]"
+        else
+            tags[at]="latest"
+        fi
 
-        #if [[ -n $tags[use] ]]; then
-        #    tags[use]="$(__zplug::utils::shell::glob2regexp "$tags[use")"
-        #else
-        #    tags[use]="$(__zplug::base::base::get_os)"
-        #    if __zplug::base::base::is_osx; then
-        #        tags[use]="(darwin|osx)"
-        #    fi
-        #fi
+        if [[ -n $tags[use] ]]; then
+            tags[use]="$(__zplug::utils::shell::glob2regexp "$tags[use]")"
+        else
+            tags[use]="$(__zplug::base::base::get_os)"
+            if __zplug::base::base::is_osx; then
+                tags[use]="(darwin|osx)"
+            fi
+        fi
     }
 
     # Get machine information
@@ -220,7 +220,8 @@ __zplug::utils::releases::index()
         return 1
     fi
 
-    mv -f "$binaries[1]" "$cmd"
+    # mv -f "$binaries[1]" "$cmd"
+    cmd="$binaries[1]"
     chmod 755 "$cmd"
     rm -rf *~"$cmd"(N)
 

--- a/base/utils/releases.zsh
+++ b/base/utils/releases.zsh
@@ -203,9 +203,6 @@ __zplug::utils::releases::index()
                 tar xvf "$artifact"
                 rm -f "$artifact"
             ;;
-        *.*)
-            return 1
-            ;;
         *)
             # Through
             ;;

--- a/misc/zshrc
+++ b/misc/zshrc
@@ -59,14 +59,14 @@ zplug clear
         from:github, \
         as:command
     # bitbucket
-    zplug "b4b4r07/hello_bitbucket", \
-        from:bitbucket, \
-        as:command, \
-        hook-build:"chmod 755 *.sh", \
-        use:"*.sh"
+    #zplug "b4b4r07/hello_bitbucket", \
+    #    from:bitbucket, \
+    #    as:command, \
+    #    hook-build:"chmod 755 *.sh", \
+    #    use:"*.sh"
     # oh-my-zsh
     zplug "plugins/emoji", from:oh-my-zsh
-    zplug "plugins/git", from:oh-my-zsh
+    #zplug "plugins/git", from:oh-my-zsh
     zplug "plugins/cp", from:oh-my-zsh
     # prezto
     zplug "modules/git", from:prezto
@@ -82,18 +82,18 @@ zplug clear
         use:"*.phar", \
         rename-to:"composer"
     # gist
-    zplug "b4b4r07/79ee61f7c140c63d2786", \
-        from:gist, \
-        as:command, \
-        use:get_last_pane_path.sh
+    #zplug "b4b4r07/79ee61f7c140c63d2786", \
+    #    from:gist, \
+    #    as:command, \
+    #    use:get_last_pane_path.sh
     # local
     ## skip
 
     tests+=(
     '(( $+functions[_zsh_highlight_bind_widgets] ))'
     '[[ -x $ZPLUG_HOME/bin/emojify ]]'
-    '[[ -x $ZPLUG_HOME/bin/hello.sh ]]'
-    '(( $+aliases[gba] ))'
+    #'[[ -x $ZPLUG_HOME/bin/hello.sh ]]'
+    #'(( $+aliases[gba] ))'
     '(( $+functions[cpv] ))'
     '(( $+functions[random_emoji] ))'
     '(( $+aliases[gbS] ))'        # "prezto" modules/git
@@ -102,7 +102,7 @@ zplug clear
     '[[ -x $ZPLUG_HOME/bin/f ]]'
     '[[ ! -x $ZPLUG_HOME/bin/peco ]]' # for b4b4r07/zsh-gomi (on tag)
     '[[ -x $ZPLUG_HOME/bin/composer ]]'
-    '[[ -x $ZPLUG_HOME/bin/get_last_pane_path.sh ]]'
+    #'[[ -x $ZPLUG_HOME/bin/get_last_pane_path.sh ]]'
     )
 }
 
@@ -125,15 +125,15 @@ zplug clear
 # hook-build
 {
     # Duplicates
-    zplug "b4b4r07/hello_bitbucket", \
-        from:bitbucket, \
-        as:command, \
-        hook-build:"chmod 755 *.sh", \
-        use:"*.sh"
+    #zplug "b4b4r07/hello_bitbucket", \
+    #    from:bitbucket, \
+    #    as:command, \
+    #    hook-build:"chmod 755 *.sh", \
+    #    use:"*.sh"
 
-    tests+=(
-    '[[ -x $ZPLUG_HOME/bin/hello.sh ]]'
-    )
+    #tests+=(
+    #'[[ -x $ZPLUG_HOME/bin/hello.sh ]]'
+    #)
 }
 
 # hook-load

--- a/misc/zshrc
+++ b/misc/zshrc
@@ -76,6 +76,11 @@ zplug clear
         as:command, \
         from:gh-r, \
         rename-to:f
+    zplug "composer/composer", \
+        as:command, \
+        from:gh-r, \
+        use:"*.phar", \
+        rename-to:"composer"
     # gist
     zplug "b4b4r07/79ee61f7c140c63d2786", \
         from:gist, \

--- a/misc/zshrc
+++ b/misc/zshrc
@@ -101,6 +101,7 @@ zplug clear
     '[[ -o autocd ]]'             # "prezto" modules/directory
     '[[ -x $ZPLUG_HOME/bin/f ]]'
     '[[ ! -x $ZPLUG_HOME/bin/peco ]]' # for b4b4r07/zsh-gomi (on tag)
+    '[[ -x $ZPLUG_HOME/bin/composer ]]'
     '[[ -x $ZPLUG_HOME/bin/get_last_pane_path.sh ]]'
     )
 }

--- a/misc/zshrc
+++ b/misc/zshrc
@@ -263,8 +263,9 @@ zplug load --verbose || ret=1
 ret=0
 for test in "$tests[@]"
 do
-    eval "$test"
-    if (( $status != 0 )); then
+    if eval "$test"; then
+        printf "$fg[green]PASS: $test$reset_color\n"
+    else
         printf "$fg[red]FAIL: $test$reset_color\n" >&2
         ret=1
     fi


### PR DESCRIPTION
I want to be able to install various formats other than a binary archive file from gh-r, e.g. [composer](https://github.com/composer/composer) like the following:

```zsh
zplug "composer/composer", \
    as:command, \
    from:gh-r, \
    use:"*.phar", \
    rename-to:"composer"
```