### PR TITLE
Fix "bad pattern" message

### DIFF
--- a/autoload/commands/__list__
+++ b/autoload/commands/__list__
@@ -89,7 +89,7 @@ if __zplug::utils::shell::is_atty; then
         builtin printf "$fg[blue] => $reset_color"
         builtin printf "${zplugs[$repo]:-"$fg[red]none"}\n"
     done \
-        | perl -pe 's/('"$tag"'):/'$fg[yellow]'$1'$reset_color':/g' \
+        | sed -E 's/('"$tag"'):/'"$fg[yellow]"'\1'"$reset_color"':/g' \
         | sed -E 's/:/:"/g;s/, /", /g;/none$/!s/$/"/g' # quotes tag
     printf "$reset_color"
 else

--- a/base/core/load.zsh
+++ b/base/core/load.zsh
@@ -82,8 +82,7 @@ __zplug::core::load::as_plugin()
 
     # Special measure
     if [[ $repo == 'zplug/zplug' ]]; then
-        __zplug::log::write::info \
-            "In the case of zplug, don't load it exceptionally"
+        # In the case of zplug, don't load it exceptionally
         return 0
     fi
 

--- a/base/job/rollback.zsh
+++ b/base/job/rollback.zsh
@@ -54,7 +54,7 @@ __zplug::job::rollback::message()
         if [[ -f $_zplug_build_log[failure] ]] || [[ -f $_zplug_build_log[timeout] ]]; then
             __zplug::io::print::f \
                 --zplug \
-                "\n$fg_bold[red]These hook-build were failed to run:$reset_color\n"
+                "$fg_bold[red]These hook-build were failed to run:$reset_color\n"
             # Listing the packages that have failed to build
             {
                 sed 's/^/ - /g' "$_zplug_build_log[failure]"

--- a/misc/completions/_zplug
+++ b/misc/completions/_zplug
@@ -58,7 +58,7 @@ case "$words[1]" in
     check)
         _arguments \
             '(--verbose)--verbose[show non-installed items in output]' \
-            '*:: :( "${(k)zplugs[@]}" )'
+            '*:: :( "${(uk)zplugs[@]:gs:@::}" )'
         ret=0
         ;;
     install)
@@ -76,7 +76,7 @@ case "$words[1]" in
     status|update)
         _arguments \
             '(--select)--select[select items with interactive filters]' \
-            '*:: :( "${(k)zplugs[@]}" )'
+            '*:: :( "${(uk)zplugs[@]:gs:@::}" )'
         ret=0
         ;;
     list)
@@ -90,7 +90,7 @@ case "$words[1]" in
         _arguments \
             '(--force --select)--force[force the removing activity]' \
             '(--select --force)--select[select items with interactive filters]' \
-            '*:: :( "${(k)zplugs[@]}" )'
+            '*:: :( "${(uk)zplugs[@]:gs:@::}" )'
         ret=0
         ;;
     clear)
@@ -100,7 +100,7 @@ case "$words[1]" in
         ;;
     info)
         _arguments \
-            '*:: :( "${(k)zplugs[@]}" )'
+            '*:: :( "${(uk)zplugs[@]:gs:@::}" )'
         ret=0
         ;;
     */*)


### PR DESCRIPTION
If set globsubst option, this error occur:

```
__list__:92: bad pattern: s/(as|use|at|ignore|lazy|commit|dir|of|rename-to|from|do|defer|file|hook-load|depth|if|nice|frozen|hook-build|on):/^[[33m
```

and several bug fixes

- Fix #350