### PR TITLE
load functions-only prezto modules

### DIFF
--- a/base/utils/prezto.zsh
+++ b/base/utils/prezto.zsh
@@ -7,7 +7,7 @@ __zplug::utils::prezto::depends()
     dependencies=()
 
     # Note: Probably the only match is init.zsh, but just in case
-    for module_f in "$prezto_repo"/modules/$module/*.zsh
+    for module_f in "$prezto_repo"/modules/$module/*.zsh(N)
     do
         dependencies+=( ${(@s: :)"$( \
             grep "\bpmodload\b" "$module_f" 2>/dev/null \


### PR DESCRIPTION
Some prezto modules (like `archive`) don't have a .zsh at all