### PR TITLE
Fix security issues with curl installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ latest | stable
 ### The best way
 
 ```console
-$ curl -sL zplug.sh/installer | zsh
+$ curl -sL --proto-redir -all,https https://zplug.sh/installer | zsh
 ```
 
 If you wonder this installation, please check it out:


### PR DESCRIPTION
The current recommended installation method has the following problems:

1. It does not explicitly use HTTPS. This means that a attacker can intercept the request before it hits the correct server and hijack it.

2. It uses the `-L` flag, which may redirect to HTTP, and is thus insecure.

To address 1, this commit adds `https://` explicitly to the URL.

To address 2, this commit adds `--proto-redir -all,https`, which forces all redirects to use HTTPS.

From reading #345 I know that https://zplug.sh always uses HTTPS.

However, a user should never have to "trust" that server is correctly configured to use HTTPS, they should interact with it in such a way that if it is not correctly configured, the request will fail.