### PR TITLE
Setup paths after variables have been initialized

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -132,8 +132,7 @@ __zplug::core::core::prepare()
 
     # Add to the PATH
     path=(
-    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
-    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
+    ${ZPLUG_BIN:-"$ZPLUG_ROOT/bin"}
     "$path[@]"
     )
 

--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -88,24 +88,6 @@ __zplug::core::core::run_interfaces()
 
 __zplug::core::core::prepare()
 {
-    # Unique array
-    typeset -gx -U path
-    typeset -gx -U fpath
-
-    # Add to the PATH
-    path=(
-    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
-    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
-    "$path[@]"
-    )
-
-    # Add to the FPATH
-    fpath=(
-    "$ZPLUG_ROOT"/misc/completions(N-/)
-    "$ZPLUG_ROOT/base/sources"
-    "$fpath[@]"
-    )
-
     # Check whether you meet the requirements for using zplug
     # 1. zsh 4.3.9 or more
     # 2. git
@@ -143,6 +125,24 @@ __zplug::core::core::prepare()
 
     # Release zplug variables and export
     __zplug::core::core::variable || return 1
+
+    # Unique array
+    typeset -gx -U path
+    typeset -gx -U fpath
+
+    # Add to the PATH
+    path=(
+    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
+    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
+    "$path[@]"
+    )
+
+    # Add to the FPATH
+    fpath=(
+    "$ZPLUG_ROOT"/misc/completions(N-/)
+    "$ZPLUG_ROOT/base/sources"
+    "$fpath[@]"
+    )
 
     mkdir -p "$ZPLUG_HOME"/{,log}
     mkdir -p "$ZPLUG_BIN"


### PR DESCRIPTION
I noticed `~/.zplug/bin` was not in my `$PATH` when using `zplug --self-manage`. It turned out `$ZPLUG_BIN` was empty because `__zplug::core::core::variable` hadn't been called.

On a sidenote, `${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}` adds `~/.zplug/repos/zplug/zplug/bin` to the path with `zplug --self-manage`. Is that intended? Otherwise it seems to equal `$ZPLUG_BIN`, which makes it redundant.
