### PR TITLE
Changed default prezto repository

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -179,7 +179,7 @@ __zplug::core::core::variable()
     typeset -gx    _ZPLUG_VERSION="2.4.1"
     typeset -gx    _ZPLUG_URL="https://github.com/zplug/zplug"
     typeset -gx    _ZPLUG_OHMYZSH="robbyrussell/oh-my-zsh"
-    typeset -gx    _ZPLUG_PREZTO="sorin-ionescu/prezto"
+    typeset -gx    _ZPLUG_PREZTO="zsh-users/prezto"
     typeset -gx    _ZPLUG_AWKPATH="$ZPLUG_ROOT/misc/contrib"
 
     # user-defined exit code 64..113


### PR DESCRIPTION
https://github.com/sorin-ionescu/prezto/commits/master
hasn't been maintained since 2016.

I propose zsh-users prezto to be default one since it seems maintained and up to date:
https://github.com/zsh-users/prezto/commits/master