### PR TITLE
update-cache: Build the cache without loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Finally, use `zplug install` to install your plugins and reload `.zshrc`.
 | `status`  | Check if the remote repositories are up to date | `--select` |
 | `clean`   | Remove repositories which are no longer managed | `--force`,`--select` |
 | `clear`   | Remove the cache file | (None) |
+| `update-cache` | Update zplug's cache files (Note: `load` does this automatically) | `--verbose` |
 | `info`    | Show the information such as the source URL and tag values for the given package | (None) |
 
 #### Take a closer look

--- a/autoload/commands/__update-cache__
+++ b/autoload/commands/__update-cache__
@@ -1,0 +1,72 @@
+#!/usr/bin/env zsh
+# Description:
+#   Update zplug's cache files (Note: `load` does this automatically)
+
+__zplug::core::load::prepare
+
+local    repo arg
+local -a repos
+local -A tags
+
+repos=( "${(k)zplugs[@]}" )
+
+while (( $# > 0 ))
+do
+    arg="$1"
+    case "$arg" in
+        --verbose)
+            zstyle ':zplug:core:load' 'verbose' yes
+            ;;
+        -*|--*)
+            __zplug::core::options::unknown "$arg"
+            return $status
+            ;;
+        "")
+            # Invalid
+            return 1
+            ;;
+        */*)
+            repos+=( "${arg:gs:@::}" )
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+    shift
+done
+
+# Check if cache is up-to-date
+if __zplug::core::cache::diff; then
+    return $status
+fi
+
+for repo in "${repos[@]}"
+do
+    # Generate cache for each as:type in parallel
+    {
+        tags[as]="$(__zplug::core::core::run_interfaces 'as' "$repo")"
+
+        case "$tags[as]" in
+            "plugin")
+                __zplug::core::cache::plugins "$repo"
+                ;;
+            "command")
+                __zplug::core::cache::commands "$repo"
+                ;;
+            "theme")
+                __zplug::core::cache::themes "$repo"
+                ;;
+            *)
+                __zplug::io::print::f \
+                    --die \
+                    --zplug \
+                    --func \
+                    "as tag is invalid value (%s)\n" \
+                    "$fg[green]$repo$reset_color"
+                ;;
+        esac
+    } &
+done
+wait
+
+return $status

--- a/autoload/zplug
+++ b/autoload/zplug
@@ -7,7 +7,7 @@ case "$arg" in
         __zplug::core::options::parse "$argv[@]"
         ;;
 
-    check | install | update | list | clean | status | clear | load | info)
+    check | install | update | list | clean | status | clear | update-cache | load | info)
         shift
         __zplug::core::core::run_interfaces \
             "$arg" \


### PR DESCRIPTION
Hi there, I recently learned about zplug and have started playing around with it. It's good stuff. I've also started evaluating it for [integration into Prezto](zsh-users/prezto#52). I'd like to find easy ways for Prezto users to install external plugins, and thought zplug might be a good way to do that!

Is there a plan to port zplug to a compiled language? I saw a note on the project board. That would be cool. I think the biggest barrier for plugin-manager adoption is speed, especially for Prezto and Zim users who are used to snappy startup.

In a proof of concept, I was able to shave a few hundred milliseconds off my startup time by pulling out bits and pieces of zplug code to handle the loading, while using zplug "as is" to manage configuration, installation, and updates. There's more to do, the logging isn’t as rich, and the code is a mess, but it was enough to prove it might work. I'd be happy to share it, though would like to clean it up first, and maybe it could be included in Prezto.

Apart from Prezto, providing this CLI option could also provide a way for other developers to optimize load speed separately from the rest of zplug.

With this change, I can use separate loading code with an unmodified copy of zplug. It's a simple thing and I hope you'll include it.