### PR TITLE
Fixed bug that `zplug --self-manage` does not work if `$ZPLUG_REPOS` is set.

### DIFF
--- a/autoload/options/__self-manage__
+++ b/autoload/options/__self-manage__
@@ -11,5 +11,5 @@ if ! __zplug::base::base::zpluged "zplug/zplug"; then
 fi
 
 ln -snf \
-    "$ZPLUG_HOME/repos/zplug/zplug/init.zsh" \
+    "$ZPLUG_REPOS/zplug/zplug/init.zsh" \
     "$ZPLUG_HOME/init.zsh"


### PR DESCRIPTION
Change `$ZPLUG_HOME/repos` to `$ZPLUG_REPOS`.

---

ユーザーによって `$ZPLUG_REPOS` が設定されてる場合 `zplug --self-manage` すると動かなくなるバグを修正しました。