### PR TITLE
Fix usage of ZPLUG_BIN

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -92,13 +92,6 @@ __zplug::core::core::prepare()
     typeset -gx -U path
     typeset -gx -U fpath
 
-    # Add to the PATH
-    path=(
-    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
-    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
-    "$path[@]"
-    )
-
     # Add to the FPATH
     fpath=(
     "$ZPLUG_ROOT"/misc/completions(N-/)
@@ -148,6 +141,13 @@ __zplug::core::core::prepare()
     mkdir -p "$ZPLUG_BIN"
     mkdir -p "$ZPLUG_CACHE_DIR"
     mkdir -p "$ZPLUG_REPOS"
+
+    # Add to the PATH
+    path=(
+    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
+    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
+    "$path[@]"
+    )
 
     touch "$_zplug_log[trace]"
 

--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -144,8 +144,7 @@ __zplug::core::core::prepare()
 
     # Add to the PATH
     path=(
-    ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
-    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
+    ${ZPLUG_BIN:-"$ZPLUG_ROOT/bin"}
     "$path[@]"
     )
 


### PR DESCRIPTION
1. Populate `PATH` **after** default value for `ZPLUG_BIN` was evaluated
2. Add `$ZPLUG_ROOT/bin` to path only if `ZPLUG_BIN` is null for some reason.