### PR TITLE
gh-r support gz file

### DIFF
--- a/base/utils/releases.zsh
+++ b/base/utils/releases.zsh
@@ -203,6 +203,9 @@ __zplug::utils::releases::index()
                 tar xvf "$artifact"
                 rm -f "$artifact"
             ;;
+        *.gz)
+                gzip -d "$artifact"
+            ;;
         *.*)
             return 1
             ;;


### PR DESCRIPTION
Hi.
I found github repository that gh-r provide single gz file, not tar.gz.

example: [vmware/govmomi](https://github.com/vmware/govmomi/releases)

I don't know zplug should support single gz file.

if you think zplug should support gz file, I feel lucky.