### PR TITLE
Fix global value 'i' to local value

### DIFF
--- a/base/io/print.zsh
+++ b/base/io/print.zsh
@@ -24,6 +24,7 @@ __zplug::io::print::f()
         is_per_specified=false
     local \
         is_log=false
+    local i
 
     if (( $argv[(I)--] )); then
         is_end_specified=true


### PR DESCRIPTION
I found a variable 'i' in zplug is not set to local so users cannot use it on console.

# Bug reproduction
## Expected:
```
> i='aaa'; echo $i
aaa
```
## Actual:
```
> i='aaa'; echo $i
0
```

# Tested environment
- Ubuntu 16.04, macOS 10.11
- zsh 5.3.1

This is my first PR. Sorry if I made something wrong.