### PR TITLE
change prezto repo from zsh-users to sorin-ionescu

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -179,7 +179,7 @@ __zplug::core::core::variable()
     typeset -gx    _ZPLUG_VERSION="2.4.1"
     typeset -gx    _ZPLUG_URL="https://github.com/zplug/zplug"
     typeset -gx    _ZPLUG_OHMYZSH="robbyrussell/oh-my-zsh"
-    typeset -gx    _ZPLUG_PREZTO="zsh-users/prezto"
+    typeset -gx    _ZPLUG_PREZTO="sorin-ionescu/prezto"
     typeset -gx    _ZPLUG_AWKPATH="$ZPLUG_ROOT/misc/contrib"
 
     # user-defined exit code 64..113


### PR DESCRIPTION
The previous repo of [prezto](https://github.com/sorin-ionescu/prezto) has been alive, and the forked zsh-users [repo](https://github.com/prezto-inactive-community-fork/prezto) was thus shuted down.