### PR TITLE
Fix printf in __zplug::job::handle::wait

### DIFF
--- a/base/job/handle.zsh
+++ b/base/job/handle.zsh
@@ -178,10 +178,9 @@ __zplug::job::handle::wait()
             if __zplug::job::process::is_running "$repo_pids[@]" "$hook_pids[@]"; then
                 builtin printf "\n"
                 __zplug::io::print::f \
-                    --zplug \
                     "Finished: %d/%d plugins\n" \
                     ${(k)#proc_states[(R)terminated]} \
-                    $#repos
+                    ${#proc_states}
             else
                 repo_pids=()
             fi


### PR DESCRIPTION
Since arguments to __zplug::io::print::f are two integers, do not prepend `[zplug]`. Also, use the `proc_states` associative array for length, not the array `repos`.

Without these changes, I get output like this:

```
[zplug] Start to [zplug] update printf: [zplug] 10: expected a numeric value
0 plugins [zplug] in parallel

 ⠙  Updating...           zsh-users/zsh-completions
 ⠹  Updating...           zsh-users/zsh-completions-completion
 ⠸  Updating...           zsh-users/zsh-completions-completion
 ⠼  Updating...           zsh-users/zsh-completions-completionch
[...]

[zplug] Finished: printf: [zplug] 0: expected a numeric value
0/printf: [zplug] 10: expected a numeric value
0 plugins
```