### PR TITLE
Add another install way

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ latest | stable
 $ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh| zsh
 ```
 
+Or you can make zsh install zplug automatically by adding following lines in your zshrc:
+
+```bash
+zshinit=~/.zplug/init.zsh
+installer=https://raw.githubusercontent.com/zplug/installer/master/installer.zsh
+# If zplug doesn't exist, install it
+source $zshinit &>/dev/null || curl -sL --proto-redir -all,https $installer | zsh && source $zshinit
+```
+
 If you wonder this installation, please check it out:
 
 - [zplug/installer](https://github.com/zplug/installer/blob/master/installer.zsh)


### PR DESCRIPTION
Add another install way which zsh will download and install the zplug automatically. Nothing will happen if it was already installed.
The benefit of this approach is that we don't need to run the install command manually. When restoring configurations on a new machine, the only thing to do is copy the zshrc file or make a symbol link.