### PR TITLE
Add hyphen to option of tar command.

### DIFF
--- a/base/utils/releases.zsh
+++ b/base/utils/releases.zsh
@@ -196,11 +196,11 @@ __zplug::utils::releases::index()
                 rm -f "$artifact"
             ;;
         *.tar.bz2)
-                tar jxvf "$artifact"
+                tar -jxvf "$artifact"
                 rm -f "$artifact"
             ;;
         *.tar.gz|*.tgz)
-                tar xvf "$artifact"
+                tar -xvf "$artifact"
                 rm -f "$artifact"
             ;;
         *.*)


### PR DESCRIPTION
`zplug 'github/hub', from:gh-r, as:command` is not working in my macOS.