### PR TITLE
Fix the installation console command so that it copies correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ latest | stable
 ### The best way
 
 ```console
-$ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh| zsh
+$ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
 ```
 
 If you wonder this installation, please check it out:


### PR DESCRIPTION
This is literally a single character fix, but the installation command in the current README has no space between the end of the `curl` command and the pipe character (`|`). Weirdly, that causes some browsers to copy the command with an extraneous `\` character, meaning that command that is copied is

`curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh\| zsh`

rather than

`curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh`

which, in turn, causes the command to fail (because the curl url throws a 404).

This fix just adds a space, which now means that the markdown renderer won't add the extraneous character.