### PR TITLE
Add additional glob for matching exact binaries in gh-r downloads

### DIFF
--- a/base/utils/releases.zsh
+++ b/base/utils/releases.zsh
@@ -213,6 +213,7 @@ __zplug::utils::releases::index()
 
     # TODO: more strictly
     binaries=()
+    binaries+=(**/$cmd(N-.))   # contains files named exactly $cmd
     binaries+=(**/*$cmd*(N-.)) # contains $cmd name files
     binaries+=(**/*(N-*))      # contains executable files
     binaries+=( $(file **/*(N-.)  | awk -F: '$2 ~ /executable/{print $1}') )


### PR DESCRIPTION
Fixes #454 by matching exact filenames before matching partially (so "__target" doesn't match before "target" in `$binaries)