### PR TITLE
$ZPLUG_BIN is not add to $PATH

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -95,7 +95,7 @@ __zplug::core::core::prepare()
     # Add to the PATH
     path=(
     ${ZPLUG_ROOT:+"$ZPLUG_ROOT/bin"}
-    ${ZPLUG_BIN:+"$ZPLUG_BIN"}
+    ${ZPLUG_BIN:-"$ZPLUG_HOME/bin"}
     "$path[@]"
     )
 


### PR DESCRIPTION
Fix `ZPLUG_BIN` was not added to `PATH` when `ZPLUG_BIN` was not declared

---

`ZPLUG_BIN` が宣言されていないときに `ZPLUG_BIN` が `PATH` に追加されなかった問題を修正