### PR TITLE
[fix] Fix for #463

### DIFF
--- a/base/base/base.zsh
+++ b/base/base/base.zsh
@@ -107,7 +107,7 @@ __zplug::base::base::git_version()
     fi
 
     __zplug::base::base::version_requirement \
-        ${(M)${(z)"$(git --version)"}:#[0-9]*[0-9]} ">" "${@:?}"
+        ${(M)${(z)"$(git --version|head -1)"}:#[0-9]*[0-9]} ">" "${@:?}"
     return $status
 }
 


### PR DESCRIPTION
Fix for #463 
[hubコマンド](https://github.com/github/hub) のaliasを設定している際に、gitコマンドのバージョンを正常に取得出来なくなるのを修正