### PR TITLE
[fix] Fix #467

### DIFF
--- a/base/job/handle.zsh
+++ b/base/job/handle.zsh
@@ -263,7 +263,7 @@ __zplug::job::handle::hook()
                 builtin printf "$repo\n" >>|"$_zplug_build_log[rollback]"
             fi
             rm -f "$_zplug_lock[job]"
-        } &
+        } &!
     fi
 
     __zplug::utils::ansi::erace_current_line


### PR DESCRIPTION
Disown background timeout process started by `__zplug::job::handle::hook()` In order to prevent the `zplug load` command from waiting for it to terminate.