### PR TITLE
Fix FPATH being exported to subprocesses

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -160,7 +160,7 @@ __zplug::core::core::prepare()
 __zplug::core::core::variable()
 {
     # for 'autoload -Uz zplug' in another subshell
-    export FPATH="$ZPLUG_ROOT/autoload:$FPATH"
+    FPATH="$ZPLUG_ROOT/autoload:$FPATH"
 
     typeset -gx    ZPLUG_HOME=${ZPLUG_HOME:-~/.zplug}
     typeset -gx -i ZPLUG_THREADS=${ZPLUG_THREADS:-16}


### PR DESCRIPTION
Fixes an issue when using zplug with multiple zsh installs, where parent zsh instances would propogate an incorrect FPATH to child instances, breaking functions. A way to see if this is verified is to run `bash` from zsh, and see if you can see the `FPATH` variable. If you can, there is an issue.

I did some limited testing with the syntax highlighting plugin and I found no issues. Let me know if you are exporting this for a reason, and I'll try to find something out. [zpm](https://github.com/zpm-zsh/zpm) seems to work fine without exporting this variable.
