### PR TITLE
resolve $ZPLUG_BIN might be "/bin"

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -162,7 +162,6 @@ __zplug::core::core::variable()
     # for 'autoload -Uz zplug' in another subshell
     export FPATH="$ZPLUG_ROOT/autoload:$FPATH"
 
-    typeset -gx    ZPLUG_HOME=${ZPLUG_HOME:-~/.zplug}
     typeset -gx -i ZPLUG_THREADS=${ZPLUG_THREADS:-16}
     typeset -gx    ZPLUG_PROTOCOL=${ZPLUG_PROTOCOL:-HTTPS}
     typeset -gx    ZPLUG_FILTER=${ZPLUG_FILTER:-"fzf-tmux:fzf:peco:percol:fzy:zaw"}

--- a/init.zsh
+++ b/init.zsh
@@ -6,6 +6,7 @@ zplugs=()
 
 # A variable as a starting point of zplug
 typeset -gx ZPLUG_ROOT="${${(%):-%N}:A:h}"
+typeset -gx ZPLUG_HOME=${ZPLUG_HOME:-~/.zplug}
 
 # Load basic functions such as an __zplug::base function
 source "$ZPLUG_ROOT/base/init.zsh"


### PR DESCRIPTION
When I haven't exported `$ZPLUG_HOME` before `source ~/.zplug/init.zsh`, `$PATH` environments always will have `/bin` at second value. This is exported at https://github.com/zplug/zplug/blob/3d47ef8f7aaf8179406fd8367435b9dbdea89582/base/core/core.zsh#L98

This Pull Request, resolve to use non-initialzed `$ZPLUG_HOME` issue.

## zsh message on initialization
### before this pull request

```
[zplug] Loaded from cache (/Users/ndxbn/.zplug/cache)
__zplug::core::load::from_cache:12: no such file or directory: /Users/ndxbn/.zplug/cache/fpath.zsh
__zplug::core::load::from_cache:source:17: no such file or directory: /Users/ndxbn/.zplug/cache/plugin.zsh
__zplug::core::load::from_cache:source:18: no such file or directory: /Users/ndxbn/.zplug/cache/lazy_plugin.zsh
__zplug::core::load::from_cache:source:19: no such file or directory: /Users/ndxbn/.zplug/cache/theme.zsh
__zplug::core::load::from_cache:source:20: no such file or directory: /Users/ndxbn/.zplug/cache/command.zsh
__zplug::core::load::from_cache:source:23: no such file or directory: /Users/ndxbn/.zplug/cache/defer_1_plugin.zsh
[zplug] Run compinit
__zplug::core::load::from_cache:source:29: no such file or directory: /Users/ndxbn/.zplug/cache/defer_2_plugin.zsh
__zplug::core::load::from_cache:source:30: no such file or directory: /Users/ndxbn/.zplug/cache/defer_3_plugin.zsh
/Users/ndxbn/.zplug/bin:/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin
```

### after this pull request

```
[zplug] Loaded from cache (/Users/ndxbn/.zplug/cache)
__zplug::core::load::from_cache:12: no such file or directory: /Users/ndxbn/.zplug/cache/fpath.zsh
__zplug::core::load::from_cache:source:17: no such file or directory: /Users/ndxbn/.zplug/cache/plugin.zsh
__zplug::core::load::from_cache:source:18: no such file or directory: /Users/ndxbn/.zplug/cache/lazy_plugin.zsh
__zplug::core::load::from_cache:source:19: no such file or directory: /Users/ndxbn/.zplug/cache/theme.zsh
__zplug::core::load::from_cache:source:20: no such file or directory: /Users/ndxbn/.zplug/cache/command.zsh
__zplug::core::load::from_cache:source:23: no such file or directory: /Users/ndxbn/.zplug/cache/defer_1_plugin.zsh
[zplug] Run compinit
__zplug::core::load::from_cache:source:29: no such file or directory: /Users/ndxbn/.zplug/cache/defer_2_plugin.zsh
__zplug::core::load::from_cache:source:30: no such file or directory: /Users/ndxbn/.zplug/cache/defer_3_plugin.zsh
/Users/ndxbn/.zplug/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

### diff
This means `$PATH` diff.

```diff
ndxbn% diff -u before after
--- before	2018-05-07 22:49:56.458305453 +0900
+++ after	2018-05-07 22:49:38.894704333 +0900
@@ -8,4 +8,5 @@
 [zplug] Run compinit
 __zplug::core::load::from_cache:source:29: no such file or directory: /Users/ndxbn/.zplug/cache/defer_2_plugin.zsh
 __zplug::core::load::from_cache:source:30: no such file or directory: /Users/ndxbn/.zplug/cache/defer_3_plugin.zsh
-/Users/ndxbn/.zplug/bin:/bin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin
+/Users/ndxbn/.zplug/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
```

## check list
- [x] `uname -a`
- [x] `cat ~/.zshrc`
- [x] `zsh --version`

### `uname -a`

```
Darwin ndxbn.local 17.5.0 Darwin Kernel Version 17.5.0: Fri Apr 13 19:32:32 PDT 2018; root:xnu-4570.51.2~1/RELEASE_X86_64 x86_64
```

### `cat ~/.zshrc`

```zsh
source ~/.zplug/init.zsh
zplug load --verbose

echo $PATH
```

### `zsh --version`

```
zsh 5.3 (x86_64-apple-darwin17.0)
```