### PR TITLE
update subcommand does not actually update package

### DIFF
--- a/base/utils/releases.zsh
+++ b/base/utils/releases.zsh
@@ -213,8 +213,9 @@ __zplug::utils::releases::index()
 
     # TODO: more strictly
     binaries=()
-    binaries+=(**/$cmd(N-.))   # contains files named exactly $cmd
-    binaries+=(**/*$cmd*(N-.)) # contains $cmd name files
+    binaries+=(*/**/$cmd(N-.)) # contains files named exactly $cmd
+    binaires+=(*/**/*$cmd*(N-.)) # contains $cmd name files
+    binaries+=(*$cmd*[^$cmd](N-.)) # contains $cmd name files in current dir
     binaries+=(**/*(N-*))      # contains executable files
     binaries+=( $(file **/*(N-.)  | awk -F: '$2 ~ /executable/{print $1}') )
     if (( $#binaries == 0 )); then


### PR DESCRIPTION
`zplug update` command does not work correctly for gh-r, I guess. It only rewrites INDEX, but leave executable file old.
Assuming that we have already installed [peco/peco](https://github.com/peco/peco) according to [Wiki](https://github.com/zplug/zplug/wiki/Configurations#examples-4),

```
zplug "peco/peco", as:command, from:gh-r
``` 

and we update it by `zplug update peco/peco`. However our command version won't change. 
In case of update, the replacement of executable in `__zplug::utils::releases::index()` do nothing as a result. For example, the variable `binaries` about `peco/peco` contains the following;

```
peco peco_linux_amd64/peco peco peco_linux_amd64/peco peco ...
``` 

the first `peco` is the version currently in use, so nothing happens by `mv -f "$binaries[1]" "$cmd"`. (`mv -f "peco" "peco"`).

I fix code to push newly downloaded file to binaries as priority.