### PR TITLE
Silence errors when running `zplug load` with no plugins

### DIFF
--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -249,6 +249,10 @@ __zplug::core::core::variable()
     "defer_2_plugin" "$ZPLUG_CACHE_DIR/defer_2_plugin.zsh"
     "defer_3_plugin" "$ZPLUG_CACHE_DIR/defer_3_plugin.zsh"
     )
+    # Ensure cache files exist before loading
+    mkdir -p "$ZPLUG_CACHE_DIR"
+    for cache_file in "$_zplug_cache[@]"
+      touch "$cache_file"
 
     typeset -gx -A _zplug_lock
     _zplug_lock=(


### PR DESCRIPTION
I installed `zplug` and added a basic setup to my `.zshrc`:
```
# zplug plugin manager
export ZPLUG_HOME=/usr/local/opt/zplug
source $ZPLUG_HOME/init.zsh

# Install plugins if there are plugins that have not been installed
if ! zplug check --verbose; then
    printf "Install? [y/N]: "
    if read -q; then
        echo; zplug install
    fi
fi

# Then, source plugins and add commands to $PATH
zplug load --verbose
```

This resulted in the following unexpected output when starting a new shell:
```
__zplug::core::load::from_cache:12: no such file or directory: /usr/local/opt/zplug/cache/fpath.zsh
__zplug::core::load::from_cache:source:17: no such file or directory: /usr/local/opt/zplug/cache/plugin.zsh
__zplug::core::load::from_cache:source:18: no such file or directory: /usr/local/opt/zplug/cache/lazy_plugin.zsh
__zplug::core::load::from_cache:source:19: no such file or directory: /usr/local/opt/zplug/cache/theme.zsh
__zplug::core::load::from_cache:source:20: no such file or directory: /usr/local/opt/zplug/cache/command.zsh
__zplug::core::load::from_cache:source:23: no such file or directory: /usr/local/opt/zplug/cache/defer_1_plugin.zsh
__zplug::core::load::from_cache:source:29: no such file or directory: /usr/local/opt/zplug/cache/defer_2_plugin.zsh
__zplug::core::load::from_cache:source:30: no such file or directory: /usr/local/opt/zplug/cache/defer_3_plugin.zsh
```

The issue is that `zplug` tries to access these files in the cache during `zplug load`, but they aren't created until at least one plugin is installed. The solution is to simply `touch` the files when `zplug` initializes, before `zplug load` runs. Here's the output of `zplug load --verbose` after the change:
```
[zplug] Loaded from cache (/usr/local/opt/zplug/cache)
[zplug] Run compinit
```