### PR TITLE
Silence compinit if ZSH_DISABLE_COMPFIX=true

### DIFF
--- a/base/core/load.zsh
+++ b/base/core/load.zsh
@@ -31,7 +31,12 @@ __zplug::core::load::from_cache()
 
         # Plugins with defer-level set
         source "$_zplug_cache[defer_1_plugin]"
-        compinit -d "$ZPLUG_HOME/zcompdump"
+        if [[ $ZSH_DISABLE_COMPFIX != true ]]; then
+          compinit -d "$ZPLUG_HOME/zcompdump"
+        else
+          compinit -u -d "$ZPLUG_HOME/zcompdump"
+        fi
+
         if (( $_zplug_boolean_true[(I)$is_verbose] )); then
             __zplug::io::print::f \
                 --zplug "$fg[yellow]Run compinit$reset_color\n"


### PR DESCRIPTION
Potential fix for https://github.com/zplug/zplug/issues/428. 

oh-my-zsh uses the same variable to enable a fix for the same problem. By adding `ZSH_DISABLE_COMPFIX=true` at the top of your `.zshrc`, you can disable compinit/compaudit warnings (this is desirable if you have multi-user permissions on your zsh and brew directories for example). 

