### PR TITLE
Remove Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,6 @@ $ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/inst
 
 Curious about the installation script? Check it out at [zplug/installer](https://github.com/zplug/installer/blob/master/installer.zsh).
 
-### Using [Homebrew](https://github.com/Homebrew/brew) (OS X)
-
-```console
-$ brew install zplug
-```
-
 ### Manually
 
 Cloning from GitHub, and source `init.zsh`:


### PR DESCRIPTION
Since Homebrew installation is faulty atm it doesn't makes sense to keep it in the readme. I spent quite a bit of time figuring out what was wrong before finding this issue: https://github.com/zplug/zplug/issues/486

It's ok that this isn't supported atm. But let's remove the install instruction for now to not confuse people. Thank you for a great package ❤️ 