### PR TITLE
Pure log

### DIFF
--- a/base/log/format.zsh
+++ b/base/log/format.zsh
@@ -2,7 +2,6 @@ __zplug::log::format::with_json()
 {
     local -i i=1
     local    level="${1:-"INFO"}" message="$2"
-    local    is_message_json=false
 
     # Spit out to JSON
     builtin printf '{'
@@ -11,14 +10,9 @@ __zplug::log::format::with_json()
     builtin printf '"level":"%s",' "$level"
     builtin printf '"dir":"%s",' "$PWD"
     builtin printf '"message":'
-    if $is_message_json; then
-        builtin printf "$message"
-    else
-        builtin printf "$message" \
-            | __zplug::utils::ansi::remove \
-            | __zplug::utils::shell::json_escape \
-            | tr -d '\n'
-    fi
+    builtin printf '%s' "$message" \
+        | __zplug::utils::ansi::remove \
+        | __zplug::utils::shell::json_escape
     builtin printf ','
     builtin printf '"trace":['
     for ((i = 1; i < $#functrace; i++))


### PR DESCRIPTION
This PR removes the Python dependency for logging. In particular, I implemented string escaping directly in Zsh. This increases logging speed and startup time, if $ZPLUG_LOADFILE does not exist (see https://github.com/zplug/zplug/issues/368#issuecomment-282566102).