### PR TITLE
Support git built from source

### DIFF
--- a/base/base/base.zsh
+++ b/base/base/base.zsh
@@ -107,7 +107,7 @@ __zplug::base::base::git_version()
     fi
 
     __zplug::base::base::version_requirement \
-        ${(M)${(z)"$(git --version|head -1)"}:#[0-9]*[0-9]} ">" "${@:?}"
+        ${(M)${(z)"$(git --version|head -1)"}:#[0-9]*} ">" "${@:?}"
     return $status
 }
 


### PR DESCRIPTION
When git is built from source, the `git version` output contains
non-numeric version components.

```
$ git version
git version 2.24.0.rc2.46.g1d34d425d4
```

zplug cannot detect the git version with this output, and it fails to
start. Change the version pattern to extract a part that starts with a
digit. For the example above, zplug will detect the git version as
"2.24.0.rc2.46.g1d34d425d4". This is good enough for the version check
while there would be no false positives.