### PR TITLE
Add support for mawk

### DIFF
--- a/base/utils/awk.zsh
+++ b/base/utils/awk.zsh
@@ -71,16 +71,30 @@ __zplug::utils::awk::ltsv()
         user_awk_script="$1" \
         ltsv_awk_script
 
-    ltsv_awk_script=$(cat <<-'EOS'
-    function key(name) {
-        for (i = 1; i <= NF; i++) {
-            match($i, ":");
-            xs[substr($i, 0, RSTART)] = substr($i, RSTART+1);
-        };
-        return xs[name":"];
-    }
+    # special script for mawk
+    if ( awk -Wv 2>&1 | grep -q mawk ); then
+       ltsv_awk_script=$(cat <<-'EOS'
+       function key(name) {
+           for (i = 1; i <= NF; i++) {
+               match($i, ":");
+               xs[substr($i, 0, RSTART)] = substr($i, RSTART+1);
+           };
+           return xs[name];
+       }
 EOS
-    )
+       )
+    else
+       ltsv_awk_script=$(cat <<-'EOS'
+       function key(name) {
+           for (i = 1; i <= NF; i++) {
+               match($i, ":");
+               xs[substr($i, 0, RSTART)] = substr($i, RSTART+1);
+           };
+           return xs[name":"];
+       }
+EOS
+       )
+    fi
 
     awk -F'\t' \
         "${ltsv_awk_script} ${user_awk_script}"


### PR DESCRIPTION
Hello,

I recently installed zplug on a vanilla Ubuntu 18.04.4 LTS distribution which apparently uses mawk and this causes an issue with the substring indexes in one of the awk scripts leading to `zplug update` leading to a bunch of `Unknown error`s. This PR should detect mawk and use a slightly different script if so.