### PR TITLE
Escape variable for sed delimiters

### DIFF
--- a/autoload/commands/__list__
+++ b/autoload/commands/__list__
@@ -89,7 +89,7 @@ if __zplug::utils::shell::is_atty; then
         builtin printf "$fg[blue] => $reset_color"
         builtin printf "${zplugs[$repo]:-"$fg[red]none"}\n"
     done \
-        | sed -E 's/('"$tag"'):/'"$fg[yellow]"'\1'"$reset_color"':/g' \
+        | sed -E 's~('"$tag:gs@/@\\/@"'):~'"$fg[yellow]"'\1'"$reset_color"':~g' \
         | sed -E 's/:/:"/g;s/, /", /g;/none$/!s/$/"/g' # quotes tag
     printf "$reset_color"
 else


### PR DESCRIPTION
I just received the error `sed: -e expression #1, char 625: unknown
option to 's'` and drilled it down to the expression in
`base/autoload/commands/__list__:92`, so we need to ensure that '/' is
escaped when `$tag` is used.

Signed-off-by: martin f. krafft <madduck@madduck.net>