### PR TITLE
use jq if available for JSON quoting

### DIFF
--- a/base/utils/shell.zsh
+++ b/base/utils/shell.zsh
@@ -257,7 +257,9 @@ __zplug::utils::shell::eval()
 
 __zplug::utils::shell::json_escape()
 {
-    if (( $+commands[python] )) && python -c 'import json' 2> /dev/null; then
+    if (( $+commands[jq] )); then
+        jq --ascii-output --raw-input --slurp .
+    elif (( $+commands[python] )) && python -c 'import json' 2> /dev/null; then
         python -c '
 from __future__ import print_function
 import json,sys


### PR DESCRIPTION
[`jq`](https://stedolan.github.io/jq/) is significantly faster than python; mainly due to start up time.