### PR TITLE
Add ZPLUG_LOG_TRACE to disable tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,11 @@ Defaults to `false`. If true, zplug spit the log about its success operation out
 
 Defaults to `false`. If true, zplug spit the log about its failure operation out to file (you can see it with `zplug --log`).
 
+#### `ZPLUG_LOG_TRACE`
+
+Defaults to `true`. If false, zplug spit trace log out to file (you can see it with `zplug --log`).
+
+
 ```zsh
 # your .zshrc
 source ~/.zshrc_secret

--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -173,6 +173,7 @@ __zplug::core::core::variable()
     typeset -gx    ZPLUG_ERROR_LOG=${ZPLUG_ERROR_LOG:-$ZPLUG_HOME/.error_log}
     typeset -gx    ZPLUG_LOG_LOAD_SUCCESS=${ZPLUG_LOG_LOAD_SUCCESS:-false}
     typeset -gx    ZPLUG_LOG_LOAD_FAILURE=${ZPLUG_LOG_LOAD_FAILURE:-false}
+    typeset -gx    ZPLUG_LOG_TRACE=${ZPLUG_LOG_TRACE:-true}
 
     typeset -gx    ZPLUG_BIN=${ZPLUG_BIN:-$ZPLUG_HOME/bin}
     typeset -gx    ZPLUG_CACHE_DIR=${ZPLUG_CACHE_DIR:-$ZPLUG_HOME/cache}

--- a/base/log/capture.zsh
+++ b/base/log/capture.zsh
@@ -6,7 +6,7 @@ __zplug::log::capture::error()
         return 0
     fi
 
-    __zplug::job::handle::flock --escape \
+    $ZPLUG_LOG_TRACE && __zplug::job::handle::flock --escape \
         "$_zplug_log[trace]" \
         "$(__zplug::log::format::with_json "ERROR" "$message")"
 }
@@ -19,7 +19,7 @@ __zplug::log::capture::debug()
         return 0
     fi
 
-    __zplug::job::handle::flock --escape \
+    $ZPLUG_LOG_TRACE && __zplug::job::handle::flock --escape \
         "$_zplug_log[trace]" \
         "$(__zplug::log::format::with_json "DEBUG" "$message")"
 }
@@ -32,7 +32,7 @@ __zplug::log::capture::info()
         return 0
     fi
 
-    __zplug::job::handle::flock --escape \
+    $ZPLUG_LOG_TRACE && __zplug::job::handle::flock --escape \
         "$_zplug_log[trace]" \
         "$(__zplug::log::format::with_json "INFO" "$message")"
 }

--- a/base/log/write.zsh
+++ b/base/log/write.zsh
@@ -1,20 +1,20 @@
 __zplug::log::write::error()
 {
-    __zplug::job::handle::flock --escape \
+    $ZPLUG_LOG_TRACE && __zplug::job::handle::flock --escape \
         "$_zplug_log[trace]" \
         "$(__zplug::log::format::with_json "ERROR" "$argv[@]")"
 }
 
 __zplug::log::write::debug()
 {
-    __zplug::job::handle::flock --escape \
+    $ZPLUG_LOG_TRACE && __zplug::job::handle::flock --escape \
         "$_zplug_log[trace]" \
         "$(__zplug::log::format::with_json "DEBUG" "$argv[@]")"
 }
 
 __zplug::log::write::info()
 {
-    __zplug::job::handle::flock --escape \
+    $ZPLUG_LOG_TRACE && __zplug::job::handle::flock --escape \
         "$_zplug_log[trace]" \
         "$(__zplug::log::format::with_json "INFO" "$argv[@]")"
 }


### PR DESCRIPTION
I agree that tracing is a good thing for troubleshooting, but trace part in `zplug` take too much time otherwise (formatting, writes and python invocation). this option adds an ability to disable this trace logging. It's still enabled by default. 

If I need to trace my zsh startup time I have in my `$ZDOTDIR/.zshrc` following code. 

```zsh
if [[ -n $ZSH_LOAD_PROFILE ]]; then
    zmodload zsh/datetime
    setopt PROMPT_SUBST
    ORIG_PS4=$PS4
    PS4='+$EPOCHREALTIME %N:%i> '

    logfile=$(mktemp $ZDOTDIR/zsh_profile.XXXXXXXX)
    echo "Logging to $logfile"
    exec 3>&2 2>$logfile
    setopt XTRACE
fi

# all usual stuff goes here, including plugin loading

if [[ -n $ZSH_LOAD_PROFILE ]]; then
    unsetopt XTRACE
    exec 2>&3 3>&-
    PS4=$ORIG_PS4
fi
```