### PR TITLE
Fix word splitting issue

### DIFF
--- a/base/utils/git.zsh
+++ b/base/utils/git.zsh
@@ -324,7 +324,7 @@ __zplug::utils::git::get_remote_state()
         state="$(grep "^ *$branch *pushes" <<<"$remote_show" | sed 's/.*(\(.*\)).*/\1/')"
 
         if [[ -z $state ]]; then
-            behind_ahead=( ${(@f)"$(git rev-list \
+            behind_ahead=( ${="$(git rev-list \
                 --left-right \
                 --count \
                 "$remote_name/$merge_branch"...$branch)"} )


### PR DESCRIPTION
By performing word splitting with ${=spec} instead of the previously
used flags, I got rid of some anoying error messages when not using
en_US.UTF-8 in LC_MESSAGES.

Fixes #419