### PR TITLE
Changes robbyrussell/oh-my-zsh to new official repo ohmyzsh/ohmyzsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - Can manage everything
   - Zsh plugins/UNIX commands on [GitHub](https://github.com) and [Bitbucket](https://bitbucket.org)
   - Gist files ([gist.github.com](https://gist.github.com))
-  - Externally managed plugins e.g., [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) and [prezto](https://github.com/sorin-ionescu/prezto) plugins/themes
+  - Externally managed plugins e.g., [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) and [prezto](https://github.com/sorin-ionescu/prezto) plugins/themes
   - Binary artifacts on [GitHub Releases](https://help.github.com/articles/about-releases/)
   - Local plugins
   - etc. (you can add your [own sources](https://github.com/zplug/zplug/blob/master/doc/guide/External-Sources.md)!)

--- a/base/core/core.zsh
+++ b/base/core/core.zsh
@@ -180,7 +180,7 @@ __zplug::core::core::variable()
 
     typeset -gx    _ZPLUG_VERSION="2.4.2"
     typeset -gx    _ZPLUG_URL="https://github.com/zplug/zplug"
-    typeset -gx    _ZPLUG_OHMYZSH="robbyrussell/oh-my-zsh"
+    typeset -gx    _ZPLUG_OHMYZSH="ohmyzsh/ohmyzsh"
     typeset -gx    _ZPLUG_PREZTO="sorin-ionescu/prezto"
     typeset -gx    _ZPLUG_AWKPATH="$ZPLUG_ROOT/misc/contrib"
 

--- a/doc/guide/External-Sources.md
+++ b/doc/guide/External-Sources.md
@@ -5,7 +5,7 @@ by zplug (yet!), you can add your own. We call these "sources."
 [GitHub](https://github.com), [Bitbucket](https://bitbucket.org), [GitHub
 Gist](https://gist.github.com), GitHub releases,
 [Gitlab](https://gitlab.com),
-[oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh), and
+[oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh), and
 [prezto](https://github.com/sorin-ionescu/prezto) are supported by default.
 Sources are what you specify with the `from` tag (e.g. `from:bitbucket`), so
 you will be able to do `from:my-foo-source`.  Writing your own sources brings

--- a/doc/guide/ja/README.md
+++ b/doc/guide/ja/README.md
@@ -18,7 +18,7 @@
 - 何でも管理できる
   - [GitHub](https://github.com) や [Bitbucket](https://bitbucket.org) にあるプラグインや UNIX コマンド
   - Gist ファイル ([gist.github.com](https://gist.github.com))
-  - 外部フレームワークなどのプラグイン (例: [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) や [prezto](https://github.com/sorin-ionescu/prezto) のプラグイン・テーマ)
+  - 外部フレームワークなどのプラグイン (例: [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) や [prezto](https://github.com/sorin-ionescu/prezto) のプラグイン・テーマ)
   - [GitHub Releases](https://help.github.com/articles/about-releases/) のバイナリファイル
   - ローカルプラグイン
   - その他 ([カスタムソース](https://github.com/zplug/zplug/blob/master/doc/zplug/External-Sources.md)によって追加できる)

--- a/doc/zplug.txt
+++ b/doc/zplug.txt
@@ -30,7 +30,7 @@ It's such a fantabulous piece of software.
     and https://bitbucket.org[Bitbucket]
 **  Gist file (https://gist.github.com[gist.github.com])
 **  Third-party sources e.g.,
- https://github.com/robbyrussell/oh-my-zsh[oh-my-zsh] and
+ https://github.com/ohmyzsh/ohmyzsh[oh-my-zsh] and
  https://github.com/sorin-ionescu/prezto[prezto] plugins/themes
 **  Binary artifacts on https://help.github.com/articles/about-releases[GitHub Releases]
 **  Local plugins


### PR DESCRIPTION
Updating all references to legacy `oh-my-zsh` repository once the official repository moved from `robbyrussell/oh-my-zsh` to `ohmyzsh/ohmyzsh` on GitHub. 🙂