### PR TITLE
Chore: Remove `$` from command line instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ latest | stable
 ### The best way
 
 ```console
-$ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
+curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
 ```
 
 Curious about the installation script? Check it out at [zplug/installer](https://github.com/zplug/installer/blob/master/installer.zsh).
@@ -53,7 +53,7 @@ Curious about the installation script? Check it out at [zplug/installer](https:/
 ### Using [Homebrew](https://github.com/Homebrew/brew) (OS X)
 
 ```console
-$ brew install zplug
+brew install zplug
 ```
 
 ### Manually
@@ -61,8 +61,8 @@ $ brew install zplug
 Cloning from GitHub, and source `init.zsh`:
 
 ```console
-$ export ZPLUG_HOME=/path/to/.zplug
-$ git clone https://github.com/zplug/zplug $ZPLUG_HOME
+export ZPLUG_HOME=/path/to/.zplug
+git clone https://github.com/zplug/zplug $ZPLUG_HOME
 ```
 
 ## Requirements


### PR DESCRIPTION
Hey folks,

This PR simply removes the `$` character from all the install instructions. 
GitHub offers a simple `Copy` text button for code snippets and this will copy `$` which makes it annoying when you just want to paste into a terminal (took me a minute to realize why I was getting 'Command not found')