### PR TITLE
fix: Improve git version extraction in base.zsh

### DIFF
--- a/base/base/base.zsh
+++ b/base/base/base.zsh
@@ -106,8 +106,13 @@ __zplug::base::base::git_version()
         return 1
     fi
 
-    __zplug::base::base::version_requirement \
-        ${(M)${(z)"$(git --version|head -1)"}:#[0-9]*} ">" "${@:?}"
+    # Extract the numeric version part from "git --version" output
+    local git_version
+    git_version="$(git --version)"
+    # Keep only numbers and dots (e.g. "git version 2.51.1.dirty" → "2.51.1")
+    git_version="${git_version//[^0-9.]/}"
+
+    __zplug::base::base::version_requirement "$git_version" ">" "${@:?}"
     return $status
 }
 


### PR DESCRIPTION
Some distributions or custom builds append `.dirty` to the git version string.
This causes __zplug::base::base::git_version() to fail because version_requirement
expects only numeric components. This patch only leaves numbers and dots in the version.

Fixes #604 