### PR TITLE
Use proper condition when displaying ahead prompt

### DIFF
--- a/base/utils/theme.zsh
+++ b/base/utils/theme.zsh
@@ -51,7 +51,7 @@ git_remote_status()
         if [[ $ahead == 0 ]] && [[ $behind == 0 ]]; then
             git_remote_status="$ZSH_THEME_GIT_PROMPT_EQUAL_REMOTE"
 
-        elif [[ $ahead == 0 ]] && [[ $behind == 0 ]]; then
+        elif [[ $ahead -gt 0 ]] && [[ $behind == 0 ]]; then
             git_remote_status="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE"
             git_remote_status_detailed="$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE_COLOR$ZSH_THEME_GIT_PROMPT_AHEAD_REMOTE$((ahead))%{$reset_color%}"
 


### PR DESCRIPTION
Fixes https://github.com/robbyrussell/oh-my-zsh/issues/7653

This is like #516, but based on `main`. #516 got closed because `master` was deleted.