### PR TITLE
Fix git version parsing and add command-level tests

### DIFF
--- a/base/base/base.zsh
+++ b/base/base/base.zsh
@@ -106,7 +106,7 @@ __zplug::base::base::git_version()
         return 1
     fi
 
-    local ver="${(M)${(z)"$(git --version|head -1)"}:#[0-9]*}"
+    local ver=${(M)${(z)"$(git --version|head -1)"}:#[0-9]*}
     # Strip non-numeric suffixes (e.g., ".dirty")
     ver="${ver%%[^0-9.]*}"
     ver="${ver%.}"

--- a/test/commands/add.t
+++ b/test/commands/add.t
@@ -1,0 +1,69 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+
+T_SUB "add registers plugin in zplugs" ((
+    zplugs=()
+    zplug "zsh-users/zsh-syntax-highlighting"
+
+    (( $+zplugs[zsh-users/zsh-syntax-highlighting] ))
+    t_ok $? "plugin is registered in zplugs"
+))
+
+T_SUB "add with tags stores tag values" ((
+    zplugs=()
+    zplug "zsh-users/zsh-syntax-highlighting", as:plugin, from:github
+
+    local entry="${zplugs[zsh-users/zsh-syntax-highlighting]}"
+    t_present "$entry" "plugin entry exists with tags"
+
+    [[ "$entry" == *as:plugin* ]]
+    t_ok $? "as:plugin is stored"
+
+    [[ "$entry" == *from:github* ]]
+    t_ok $? "from:github is stored"
+))
+
+T_SUB "add rejects invalid package name" ((
+    zplugs=()
+    zplug "invalid-name-no-slash" 2>/dev/null
+    t_isnt $status 0 "returns non-zero for invalid name"
+
+    (( ! $+zplugs[invalid-name-no-slash] ))
+    t_ok $? "invalid name is not added to zplugs"
+))
+
+T_SUB "add rejects invalid tag name" ((
+    zplugs=()
+    zplug "user/repo", nonexistent:value 2>/dev/null
+    t_isnt $status 0 "returns non-zero for invalid tag"
+))
+
+T_SUB "add handles duplicate names with at-sign suffix" ((
+    zplugs=()
+    zplug "plugins/git", from:oh-my-zsh
+    zplug "plugins/git", from:prezto
+
+    local -i count=0
+    local key
+    for key in "${(k)zplugs[@]}"; do
+        [[ "$key" == plugins/git* ]] && (( count++ ))
+    done
+    t_ge $count 2 "both entries exist (possibly with @ suffix)"
+))
+
+T_SUB "add multiple plugins independently" ((
+    zplugs=()
+    zplug "user/plugin-a"
+    zplug "user/plugin-b"
+    zplug "user/plugin-c"
+
+    (( $+zplugs[user/plugin-a] ))
+    t_ok $? "plugin-a registered"
+
+    (( $+zplugs[user/plugin-b] ))
+    t_ok $? "plugin-b registered"
+
+    (( $+zplugs[user/plugin-c] ))
+    t_ok $? "plugin-c registered"
+))

--- a/test/commands/check.t
+++ b/test/commands/check.t
@@ -1,0 +1,65 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+
+T_SUB "check returns non-zero when plugin is not installed" ((
+    zplugs=()
+    zplug "zsh-users/zsh-syntax-highlighting"
+
+    zplug check "zsh-users/zsh-syntax-highlighting" 2>/dev/null
+    t_isnt $status 0 "uninstalled plugin returns non-zero"
+))
+
+T_SUB "check returns non-zero when no plugins installed" ((
+    zplugs=()
+    zplug "user/plugin-a"
+    zplug "user/plugin-b"
+
+    zplug check 2>/dev/null
+    t_isnt $status 0 "check all returns non-zero when none installed"
+))
+
+T_SUB "check with --verbose produces output" ((
+    zplugs=()
+    zplug "zsh-users/zsh-syntax-highlighting"
+
+    local output
+    output="$(zplug check --verbose 2>&1)"
+    t_present "$output" "verbose mode produces output"
+))
+
+T_SUB "check with --debug outputs repo names" ((
+    zplugs=()
+    zplug "zsh-users/zsh-syntax-highlighting"
+
+    local output
+    output="$(zplug check --debug 2>/dev/null)"
+    t_present "$output" "debug mode outputs repo names"
+
+    [[ "$output" == *zsh-users/zsh-syntax-highlighting* ]]
+    t_ok $? "debug output contains the uninstalled repo name"
+))
+
+T_SUB "check skips plugins with false if condition" ((
+    zplugs=()
+    zplug "user/conditional-plugin", if:"false"
+
+    # Plugin with if:false should be skipped, not counted as missing
+    zplug check "user/conditional-plugin" 2>/dev/null
+    # Skipped plugins return success (not counted as not-installed)
+    t_is $status 0 "plugin with false if-condition is skipped"
+))
+
+T_SUB "check succeeds for installed plugin" ((
+    zplugs=()
+    local repo="fake-user/fake-plugin"
+    zplug "$repo"
+
+    # Simulate installed state by creating the directory with a git repo
+    mkdir -p "$ZPLUG_REPOS/$repo"
+    git -C "$ZPLUG_REPOS/$repo" init --quiet 2>/dev/null
+    git -C "$ZPLUG_REPOS/$repo" commit --allow-empty -m "init" --quiet 2>/dev/null
+
+    zplug check "$repo" 2>/dev/null
+    t_is $status 0 "check returns 0 for installed plugin"
+))

--- a/test/commands/clean.t
+++ b/test/commands/clean.t
@@ -1,0 +1,43 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+
+T_SUB "clean --force removes unmanaged repo directory" ((
+    zplugs=()
+
+    # Create an unmanaged repo directory (not in zplugs)
+    local orphan_dir="$ZPLUG_REPOS/orphan-user/orphan-plugin"
+    mkdir -p "$orphan_dir"
+
+    zplug clean --force 2>/dev/null
+
+    [[ ! -d "$orphan_dir" ]]
+    t_ok $? "unmanaged directory is removed"
+))
+
+T_SUB "clean --force does not remove managed repo" ((
+    zplugs=()
+    local repo="user/managed-plugin"
+    zplug "$repo"
+
+    # Create the managed repo directory
+    mkdir -p "$ZPLUG_REPOS/$repo"
+
+    zplug clean --force 2>/dev/null
+
+    t_directory "$ZPLUG_REPOS/$repo" "managed directory is preserved"
+))
+
+T_SUB "clean --force removes specified repo" ((
+    zplugs=()
+    local repo="user/to-remove"
+    zplug "$repo"
+
+    # Create the repo directory
+    mkdir -p "$ZPLUG_REPOS/$repo"
+
+    zplug clean --force "$repo" 2>/dev/null
+
+    [[ ! -d "$ZPLUG_REPOS/$repo" ]]
+    t_ok $? "specified directory is removed"
+))

--- a/test/commands/list.t
+++ b/test/commands/list.t
@@ -1,0 +1,35 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+
+T_SUB "list shows error when no plugins registered" ((
+    zplugs=()
+
+    zplug list 2>/dev/null
+    t_isnt $status 0 "returns non-zero when zplugs is empty"
+))
+
+T_SUB "list succeeds when plugins are registered" ((
+    zplugs=()
+    zplug "user/plugin-a"
+    zplug "user/plugin-b"
+
+    local output
+    output="$(zplug list 2>/dev/null)"
+    t_is $status 0 "returns 0 when plugins exist"
+))
+
+T_SUB "list output contains registered plugin names" ((
+    zplugs=()
+    zplug "user/plugin-a"
+    zplug "user/plugin-b"
+
+    local output
+    output="$(zplug list 2>&1)"
+
+    [[ "$output" == *user/plugin-a* ]]
+    t_ok $? "output contains plugin-a"
+
+    [[ "$output" == *user/plugin-b* ]]
+    t_ok $? "output contains plugin-b"
+))

--- a/test/helper.zsh
+++ b/test/helper.zsh
@@ -1,0 +1,22 @@
+# test/helper.zsh — Common test setup for command-level tests
+#
+# Source this file at the top of each .t file:
+#   source "$ZPLUG_ROOT/test/helper.zsh"
+
+# Isolated ZPLUG_HOME per test file
+export ZPLUG_HOME="$(mktemp -d)"
+export ZPLUG_REPOS="$ZPLUG_HOME/repos"
+export ZPLUG_BIN="$ZPLUG_HOME/bin"
+export ZPLUG_LOADFILE="$ZPLUG_HOME/packages.zsh"
+export ZPLUG_USE_CACHE=false
+
+# Initialize zplug
+source "$ZPLUG_ROOT/init.zsh"
+
+# Reset state
+zplugs=()
+
+cleanup() {
+    rm -rf "$ZPLUG_HOME"
+}
+trap cleanup EXIT


### PR DESCRIPTION
## Summary
Add command-level characterization tests for zplug's public commands (add, check, list, clean) to serve as a safety net before large-scale refactoring. Also fix a git version parsing bug discovered during test development.

## Background
All 111 existing test cases were stubbed with `# skip` — zero implemented tests. There was no way to detect regressions during refactoring. Rather than unit tests (which couple to internal implementation), command-level tests capture observable behavior from the user's perspective and survive internal restructuring.

While building the test infrastructure, discovered that `__zplug::base::base::git_version()` fails on zsh 5.9. The double-quoted array expansion `"${(M)${(z)...}:#[0-9]*}"` joins the array into a scalar before glob matching, causing version extraction to always return empty.

## Changes

### Bug fix: `base/base/base.zsh`
- Remove double quotes from array filtering expansion in `git_version()`
- `"${(M)${(z)...}:#[0-9]*}"` → `${(M)${(z)...}:#[0-9]*}`
- Fixes version parsing on zsh 5.9 + Apple Git (`git version 2.39.5 (Apple Git-154)`)

### Test infrastructure: `test/helper.zsh`
- Creates isolated `ZPLUG_HOME` in temp directory
- Common init and cleanup for all command-level tests

### Command-level tests: `test/commands/`
| File | Tests | Coverage |
|------|-------|----------|
| `add.t` | 6 | Registration, tag storage, invalid name/tag rejection, duplicate handling, multiple plugins |
| `check.t` | 6 | Uninstalled detection, verbose/debug output, if-condition skip, installed plugin |
| `list.t` | 3 | Empty error, registered success, output content |
| `clean.t` | 3 | Unmanaged removal, managed preservation, targeted removal |

All 18 tests run without network access (no mocks needed).