### PR TITLE
Add tag defaults, install/load tests with fixture infrastructure

### DIFF
--- a/doc/internal/testing-strategy.md
+++ b/doc/internal/testing-strategy.md
@@ -3,10 +3,10 @@
 ## Current State
 
 - Test framework: [Shove](https://github.com/key-amb/shove) v0.8.4 (TAP output)
-- 27 test files, 111 test cases — **all `# skip` (no implementations)**
-- Only working test: `test/all.t` (E2E integration via `misc/zshrc`)
-- 18 modules have no test files at all (job/, log/ systems especially)
 - Test runner: `make test` → `shove -r test/ -s zsh`
+- **43 command-level tests** across 7 files (all passing)
+- 27 unit test stub files in `test/base/` (111 cases, all `# skip`)
+- E2E integration test: `test/all.t` (known job table exhaustion issue)
 
 ## Approach: Command-Level Tests First
 
@@ -17,26 +17,29 @@ resulting in double the rewrite work.
 Instead, write **command-level characterization tests** that capture observable
 behavior from the user's perspective. These survive internal restructuring.
 
-### What NOT to test first
+## Test Coverage
 
-- Internal function return values
-- Data structure internals (how `zplugs` is populated)
-- Log output format
-- Individual utility functions
+### Phase 1: No-mock tests (DONE)
 
-### What to test first
+| File | Tests | What it covers |
+|------|-------|---------------|
+| `test/commands/add.t` | 6 | Registration, tag storage, invalid name/tag rejection, duplicates, multiple plugins |
+| `test/commands/check.t` | 6 | Uninstalled detection, verbose/debug output, if-condition skip, installed判定 |
+| `test/commands/list.t` | 3 | Empty error, registered success, output content |
+| `test/commands/clean.t` | 3 | Unmanaged removal, managed preservation, targeted removal |
+| `test/commands/tags.t` | 16 | Default values (as, from, at, use, frozen, lazy, defer, depth, dir), explicit overrides, gh-r defaults |
 
-The public CLI commands and their observable effects:
+### Phase 2: Install/load tests with fixtures (DONE)
 
-| Command | Observable Effect |
-|---------|-------------------|
-| `zplug "user/repo"` | Registered in `zplugs` associative array |
-| `zplug check` | Exit code reflects install state |
-| `zplug list` | Lists registered plugins |
-| `zplug install` | Creates directory under `$ZPLUG_HOME/repos/` |
-| `zplug load` | Functions/commands become available in shell |
-| `zplug clean` | Removes plugin directory |
-| `zplug update` | Updates cloned repository |
+| File | Tests | What it covers |
+|------|-------|---------------|
+| `test/commands/install.t` | 5 | Clone to ZPLUG_REPOS, plugin file creation, check after install, skip-if, idempotent install |
+| `test/commands/load.t` | 4 | Plugin sourcing, function availability, command symlink, fpath for completions |
+
+### Phase 3: Unit tests (after refactoring)
+
+Write unit tests for the new internal design to lock it in.
+Use the existing Shove stubs in `test/base/` as a starting point.
 
 ## Network Dependency Handling
 
@@ -52,22 +55,10 @@ Most commands, however, do not.
 - `zplug load` — sources files from disk
 - Tag default resolution — pure logic
 
-**These cover the majority of refactoring-sensitive logic.** Start here.
-
 ### Commands that need mocking
 
 - `zplug install` — calls `git clone` or `curl`/`wget`
 - `zplug update` — calls `git fetch`/`merge` or `curl`/`wget`
-
-### Network operation touchpoints
-
-| Operation | Function | How it calls |
-|-----------|----------|-------------|
-| git clone | `__zplug::utils::git::clone()` | bare `git clone` (no `command` prefix) |
-| git fetch/merge | `__zplug::utils::git::merge()` | bare `git fetch`, `git merge` |
-| curl (releases) | `__zplug::utils::releases::get_url()` | `command curl` (bypasses functions) |
-| curl (download) | `__zplug::utils::releases::get()` | `command curl` (bypasses functions) |
-| URL resolution | `__zplug::sources::<source>::get_url()` | returns URL string |
 
 ### Mocking strategy
 
@@ -76,36 +67,21 @@ Most commands, however, do not.
 Override `get_url()` to return `file://` URLs pointing to local fixtures.
 Real `git clone`/`fetch` runs without network.
 
-```zsh
-# Override in test setup
-__zplug::sources::github::get_url() {
-    echo "file://$FIXTURE_ROOT/${1}.git"
-}
-```
+**IMPORTANT**: The override must be placed AFTER `zplug "user/repo"`, not before.
+The `zplug` add command calls `__zplug::core::sources::call()` which re-sources
+`github.zsh` from disk, overwriting any prior function override.
 
-`get_url()` is a stable interface boundary — it will exist in any reasonable
-refactoring of the source handler system.
+```zsh
+zplugs=()
+zplug "test-user/test-plugin"
+_setup_fixture_url_override   # AFTER add, not before
+zplug install
+```
 
 **curl/wget-based sources (gh-r) → PATH mock**
 
 `command curl` bypasses function overrides but still uses PATH lookup.
 Place a mock script at `test/mock/bin/curl` and prepend to PATH.
-
-```bash
-#!/bin/bash
-# test/mock/bin/curl — returns canned responses based on URL
-url="${@: -1}"
-case "$url" in
-    *releases/latest*) cat "$FIXTURE_ROOT/releases_latest.html" ;;
-    *releases/download/*) cp "$FIXTURE_ROOT/dummy.tar.gz" . ;;
-    *) echo "mock curl: unexpected URL: $url" >&2; exit 1 ;;
-esac
-```
-
-```zsh
-# In test setup
-export PATH="$ZPLUG_ROOT/test/mock/bin:$PATH"
-```
 
 ## Test Infrastructure
 
@@ -117,77 +93,44 @@ test/
 ├── fixtures/
 │   └── setup.zsh         # Create local bare repos for install/update tests
 ├── mock/
-│   └── bin/
-│       └── curl           # PATH-based curl mock for gh-r tests
-├── commands/              # Command-level tests (new)
+│   └── bin/              # PATH-based mocks (curl for gh-r tests)
+├── commands/             # Command-level tests
 │   ├── add.t
 │   ├── check.t
-│   ├── list.t
 │   ├── clean.t
-│   ├── load.t
 │   ├── install.t
-│   └── update.t
-└── base/                  # Existing unit test stubs (implement after refactoring)
+│   ├── list.t
+│   ├── load.t
+│   └── tags.t
+└── base/                 # Existing unit test stubs (implement after refactoring)
     └── ...
 ```
 
-### Test helper template
+### Running tests
 
-```zsh
-# test/helper.zsh
-
-export ZPLUG_HOME="$(mktemp -d)"
-source "$ZPLUG_ROOT/init.zsh"
-
-cleanup() {
-    rm -rf "$ZPLUG_HOME"
-}
-trap cleanup EXIT
+```sh
+make test TEST_TARGET=test/commands/          # all command tests
+make test TEST_TARGET=test/commands/add.t     # single file
 ```
 
-### Fixture helper for install/update tests
+### Fixture repos
 
-```zsh
-# test/fixtures/setup.zsh
+Fixture bare repos use `--initial-branch=master` because zplug defaults
+`at:master`. Each test file creates fixtures at setup and cleans up on exit.
 
-setup_fixture_repo() {
-    local name="$1"
-    local bare_dir="$FIXTURE_ROOT/$name.git"
-    local work="$(mktemp -d)"
+## Gotchas Discovered
 
-    git init --bare "$bare_dir" &>/dev/null
-    git clone "$bare_dir" "$work" &>/dev/null
-    echo "# dummy" > "$work/${name##*/}.plugin.zsh"
-    git -C "$work" add -A &>/dev/null
-    git -C "$work" commit -m "init" &>/dev/null
-    git -C "$work" push origin master &>/dev/null
-    rm -rf "$work"
-}
-```
+- **`"${(M)${(z)...}:#pattern}"` bug**: Double-quoting a zsh array filter
+  expansion joins the array to scalar before matching. Remove outer quotes.
+  (Fixed in `base/base/base.zsh` `git_version()`)
 
-## Implementation Phases
+- **`T_SUB` subshell isolation**: Each test group runs in `(...)`. Filesystem
+  changes persist but variable changes do not leak. Install tests must create
+  directories within each T_SUB independently.
 
-### Phase 1: No-mock tests (before refactoring)
+- **Source handler reload**: `zplug "user/repo"` with `from:` tag calls
+  `__zplug::core::sources::call()` which re-sources handler files from disk.
+  Function overrides must be placed after the add call.
 
-Write command-level tests for add, check, list, clean, and tag defaults.
-No fixtures or mocks needed. This is the immediate priority.
-
-### Phase 2: Install/update tests (before refactoring)
-
-Set up fixture infrastructure (local bare repos, curl mock).
-Write tests for install and load with fixture plugins.
-
-### Phase 3: Unit tests (after refactoring)
-
-Write unit tests for the new internal design to lock it in.
-Use the existing Shove stubs in `test/base/` as a starting point.
-
-## Notes
-
-- Shove's `T_SUB` runs in a subshell — global state (`zplugs`) doesn't leak
-  between test groups. This is a benefit for isolation.
-- `source "$ZPLUG_ROOT/init.zsh"` is heavy. Source once per test file, not per
-  `T_SUB` block.
-- Zsh arrays are 1-indexed. Guard against off-by-one in assertions.
-- Existing `test/all.t` has a known failure (job table exhaustion). Individual
-  tests are the reliable signal.
+- **Default branch**: Modern git defaults to `main`, but zplug defaults `at:master`.
+  Fixture repos must use `--initial-branch=master` to match.

--- a/test/commands/install.t
+++ b/test/commands/install.t
@@ -1,0 +1,65 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+source "$ZPLUG_ROOT/test/fixtures/setup.zsh"
+
+# Set up fixture repos
+setup_fixture_repo "test-user/test-plugin"
+
+T_SUB "install clones plugin to ZPLUG_REPOS" ((
+    zplugs=()
+    zplug "test-user/test-plugin"
+    _setup_fixture_url_override  # must be after zplug add
+
+    zplug install 2>/dev/null
+
+    t_directory "$ZPLUG_REPOS/test-user/test-plugin" \
+        "plugin directory exists after install"
+))
+
+T_SUB "install creates plugin file in cloned repo" ((
+    zplugs=()
+    zplug "test-user/test-plugin"
+    _setup_fixture_url_override
+
+    zplug install 2>/dev/null
+
+    t_file "$ZPLUG_REPOS/test-user/test-plugin/test-plugin.plugin.zsh" \
+        "plugin file exists in cloned repo"
+))
+
+T_SUB "check returns 0 after install" ((
+    zplugs=()
+    zplug "test-user/test-plugin"
+    _setup_fixture_url_override
+
+    zplug install 2>/dev/null
+    zplug check "test-user/test-plugin" 2>/dev/null
+
+    t_is $status 0 "check succeeds after install"
+))
+
+T_SUB "install skips already installed plugin" ((
+    zplugs=()
+    zplug "test-user/test-plugin"
+    _setup_fixture_url_override
+
+    zplug install 2>/dev/null
+    zplug install 2>/dev/null
+
+    t_directory "$ZPLUG_REPOS/test-user/test-plugin" \
+        "plugin directory still exists"
+))
+
+T_SUB "install skips plugin with false if condition" ((
+    zplugs=()
+    zplug "test-user/test-plugin", if:"false"
+    _setup_fixture_url_override
+
+    zplug install 2>/dev/null
+
+    [[ ! -d "$ZPLUG_REPOS/test-user/test-plugin" ]]
+    t_ok $? "plugin with false if-condition is not installed"
+))
+
+_cleanup_fixtures

--- a/test/commands/load.t
+++ b/test/commands/load.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+source "$ZPLUG_ROOT/test/fixtures/setup.zsh"
+
+# Create fixture with a plugin that defines a function
+setup_fixture_repo "test-user/test-plugin"
+_setup_fixture_url_override
+
+# Pre-install: create the repo content manually for load tests
+# (to avoid depending on install working correctly)
+_setup_installed_plugin() {
+    local repo="$1" plugin_file="$2"
+    local dir="$ZPLUG_REPOS/$repo"
+    mkdir -p "$dir"
+    git -C "$dir" init --quiet 2>/dev/null
+    echo "$plugin_file" > "$dir/${repo:t}.plugin.zsh"
+    git -C "$dir" add -A 2>/dev/null
+    git -C "$dir" commit -m "init" --quiet 2>/dev/null
+}
+
+T_SUB "load sources plugin file" ((
+    zplugs=()
+    _setup_installed_plugin "test-user/load-test" \
+        '_zplug_test_loaded=1'
+
+    zplug "test-user/load-test"
+    zplug load 2>/dev/null
+
+    t_is "${_zplug_test_loaded:-0}" "1" "plugin file was sourced"
+))
+
+T_SUB "load makes function available" ((
+    zplugs=()
+    _setup_installed_plugin "test-user/func-test" \
+        'zplug_test_func() { echo "hello from test"; }'
+
+    zplug "test-user/func-test"
+    zplug load 2>/dev/null
+
+    (( $+functions[zplug_test_func] ))
+    t_ok $? "function defined by plugin is available"
+))
+
+T_SUB "load creates command symlink for as:command" ((
+    zplugs=()
+    local dir="$ZPLUG_REPOS/test-user/cmd-test"
+    mkdir -p "$dir"
+    git -C "$dir" init --quiet 2>/dev/null
+    echo '#!/bin/sh' > "$dir/cmd-test"
+    echo 'echo cmd-test' >> "$dir/cmd-test"
+    chmod +x "$dir/cmd-test"
+    git -C "$dir" add -A 2>/dev/null
+    git -C "$dir" commit -m "init" --quiet 2>/dev/null
+
+    zplug "test-user/cmd-test", as:command
+    zplug load 2>/dev/null
+
+    # Check that a symlink or file exists in ZPLUG_BIN
+    [[ -e "$ZPLUG_BIN/cmd-test" ]]
+    t_ok $? "command symlink exists in ZPLUG_BIN"
+))
+
+T_SUB "load adds fpath for plugin with completions" ((
+    zplugs=()
+    local dir="$ZPLUG_REPOS/test-user/comp-test"
+    mkdir -p "$dir"
+    git -C "$dir" init --quiet 2>/dev/null
+    echo '# plugin' > "$dir/comp-test.plugin.zsh"
+    echo '#compdef comp-test' > "$dir/_comp-test"
+    git -C "$dir" add -A 2>/dev/null
+    git -C "$dir" commit -m "init" --quiet 2>/dev/null
+
+    zplug "test-user/comp-test"
+    zplug load 2>/dev/null
+
+    [[ "${fpath[(r)$dir]}" == "$dir" ]]
+    t_ok $? "plugin directory added to fpath"
+))
+
+_cleanup_fixtures

--- a/test/commands/tags.t
+++ b/test/commands/tags.t
@@ -1,0 +1,145 @@
+#!/usr/bin/env zsh
+
+source "$ZPLUG_ROOT/test/helper.zsh"
+
+# Helper: parse tags for a repo into associative array $tags
+_parse_tags() {
+    __zplug::core::tags::parse "$1"
+    tags=( "${reply[@]}" )
+}
+
+#
+# Default values
+#
+
+T_SUB "default as is plugin" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[as]" "plugin" "as defaults to plugin"
+))
+
+T_SUB "default from is github" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[from]" "github" "from defaults to github"
+))
+
+T_SUB "default at is master" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[at]" "master" "at defaults to master"
+))
+
+T_SUB "default at is latest for gh-r" ((
+    zplugs=()
+    zplug "user/repo", from:gh-r, as:command
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[at]" "latest" "at defaults to latest for gh-r"
+))
+
+T_SUB "default use is *.zsh" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[use]" "*.zsh" "use defaults to *.zsh"
+))
+
+T_SUB "default frozen is no" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[frozen]" "no" "frozen defaults to no"
+))
+
+T_SUB "default lazy is no" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[lazy]" "no" "lazy defaults to no"
+))
+
+T_SUB "default defer is 0" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[defer]" "0" "defer defaults to 0"
+))
+
+T_SUB "default depth is 0" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[depth]" "0" "depth defaults to 0"
+))
+
+T_SUB "dir defaults to ZPLUG_REPOS/repo" ((
+    zplugs=()
+    zplug "user/repo"
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[dir]" "$ZPLUG_REPOS/user/repo" "dir defaults to repos/user/repo"
+))
+
+#
+# Explicit tag values
+#
+
+T_SUB "explicit as:command is respected" ((
+    zplugs=()
+    zplug "user/repo", as:command
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[as]" "command" "as is command"
+))
+
+T_SUB "explicit as:theme is respected" ((
+    zplugs=()
+    zplug "user/repo", as:theme
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[as]" "theme" "as is theme"
+))
+
+T_SUB "explicit at:dev is respected" ((
+    zplugs=()
+    zplug "user/repo", at:dev
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[at]" "dev" "at is dev"
+))
+
+T_SUB "explicit frozen:yes is respected" ((
+    zplugs=()
+    zplug "user/repo", frozen:yes
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[frozen]" "yes" "frozen is yes"
+))
+
+T_SUB "explicit defer:2 is respected" ((
+    zplugs=()
+    zplug "user/repo", defer:2
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[defer]" "2" "defer is 2"
+))
+
+T_SUB "explicit depth:1 is respected" ((
+    zplugs=()
+    zplug "user/repo", depth:1
+    local -A tags; _parse_tags "user/repo"
+
+    t_is "$tags[depth]" "1" "depth is 1"
+))

--- a/test/fixtures/setup.zsh
+++ b/test/fixtures/setup.zsh
@@ -1,0 +1,71 @@
+# test/fixtures/setup.zsh — Create local bare git repos for testing
+
+FIXTURE_ROOT="$(mktemp -d)"
+
+# Create a bare git repo that can be cloned via file:// protocol
+# Usage: setup_fixture_repo "user/repo" [files...]
+#   If no files given, creates a default .plugin.zsh file
+setup_fixture_repo() {
+    local name="$1"; shift
+    local bare_dir="$FIXTURE_ROOT/$name.git"
+    local work="$(mktemp -d)"
+
+    mkdir -p "${bare_dir:h}"
+    git init --bare --initial-branch=master "$bare_dir" --quiet 2>/dev/null
+
+    git clone "$bare_dir" "$work" --quiet 2>/dev/null
+    git -C "$work" checkout -b master --quiet 2>/dev/null
+
+    if (( $# > 0 )); then
+        # Create specified files
+        for f in "$@"; do
+            mkdir -p "$work/${f:h}"
+            echo "# fixture: $f" > "$work/$f"
+        done
+    else
+        # Default: create a plugin file
+        echo "# fixture plugin" > "$work/${name:t}.plugin.zsh"
+    fi
+
+    git -C "$work" add -A 2>/dev/null
+    git -C "$work" commit -m "init" --quiet 2>/dev/null
+    git -C "$work" push origin master --quiet 2>/dev/null
+    rm -rf "$work"
+}
+
+# Create a fixture repo with a branch
+# Usage: setup_fixture_branch "user/repo" "branch-name" [files...]
+setup_fixture_branch() {
+    local name="$1" branch="$2"; shift 2
+    local bare_dir="$FIXTURE_ROOT/$name.git"
+    local work="$(mktemp -d)"
+
+    git clone "$bare_dir" "$work" --quiet 2>/dev/null
+    git -C "$work" checkout -b "$branch" --quiet 2>/dev/null
+
+    if (( $# > 0 )); then
+        for f in "$@"; do
+            mkdir -p "$work/${f:h}"
+            echo "# fixture: $f (branch: $branch)" > "$work/$f"
+        done
+    else
+        echo "# branch: $branch" >> "$work/${name:t}.plugin.zsh"
+    fi
+
+    git -C "$work" add -A 2>/dev/null
+    git -C "$work" commit -m "branch $branch" --quiet 2>/dev/null
+    git -C "$work" push origin "$branch" --quiet 2>/dev/null
+    rm -rf "$work"
+}
+
+# Override get_url to point to local fixture repos
+_setup_fixture_url_override() {
+    __zplug::sources::github::get_url() {
+        echo "file://$FIXTURE_ROOT/${1}.git"
+    }
+}
+
+# Cleanup fixtures
+_cleanup_fixtures() {
+    rm -rf "$FIXTURE_ROOT"
+}


### PR DESCRIPTION
## Summary
Continues the test infrastructure work from #610 by completing Phase 1 (tag default tests) and Phase 2 (install/load tests with local git fixture repos). The command-level test suite now covers 43 tests across 7 files, all passing without network access.

## Background
PR #610 established the command-level testing approach and created tests for add, check, list, and clean commands. This PR completes the remaining phases of the testing strategy defined in `doc/internal/testing-strategy.md` — tag default verification and install/load tests that require mocked network operations.

## Changes

### `test/commands/tags.t` (16 tests)
Verifies tag default values resolved via `__zplug::core::tags::parse`:
- Default values: `as:plugin`, `from:github`, `at:master`, `use:*.zsh`, `frozen:no`, `lazy:no`, `defer:0`, `depth:0`, `dir:$ZPLUG_REPOS/user/repo`
- Dynamic defaults: `at:latest` for `from:gh-r` sources
- Explicit tag overrides: `as:command`, `as:theme`, `at:dev`, `frozen:yes`, `defer:2`, `depth:1`

### `test/fixtures/setup.zsh` — Fixture infrastructure
- `setup_fixture_repo()` creates local bare git repos with `--initial-branch=master` (matching zplug's `at:master` default)
- `setup_fixture_branch()` adds named branches to fixture repos
- `_setup_fixture_url_override()` overrides `get_url()` to return `file://` URLs — must be called **after** `zplug add` since `sources::call()` re-sources handler files from disk
- `_cleanup_fixtures()` for teardown

### `test/commands/install.t` (5 tests)
Tests install via local bare repos (no network):
- Clone creates directory and plugin file under `$ZPLUG_REPOS`
- `check` returns 0 after successful install
- Idempotent re-install
- `if:"false"` condition skips installation

### `test/commands/load.t` (4 tests)
Tests load with pre-created plugin directories:
- Plugin file is sourced (variable set by plugin is accessible)
- Functions defined in plugin become available
- `as:command` creates symlink in `$ZPLUG_BIN`
- Completion files (`_*`) add directory to `fpath`

### `doc/internal/testing-strategy.md`
Updated to reflect completed phases, document discovered gotchas (override ordering, default branch mismatch, zsh array expansion bug), and provide accurate test counts.

## Related
- Follows up on #610