### PR TITLE
fix: check cache files exist before sourcing in from_cache

### DIFF
--- a/base/core/load.zsh
+++ b/base/core/load.zsh
@@ -18,26 +18,30 @@ __zplug::core::load::from_cache()
     __zplug::core::cache::update
 
     # Load the cache in order
+    # The cache files may not exist (e.g. fresh install with no
+    # packages registered), so check before sourcing
     {
-        fpath=(
-        ${(@f)"$(<$_zplug_cache[fpath])"}
-        "$fpath[@]"
-        )
+        if [[ -s $_zplug_cache[fpath] ]]; then
+            fpath=(
+            ${(@f)"$(<$_zplug_cache[fpath])"}
+            "$fpath[@]"
+            )
+        fi
 
-        source "$_zplug_cache[plugin]"
-        source "$_zplug_cache[lazy_plugin]"
-        source "$_zplug_cache[theme]"
-        source "$_zplug_cache[command]"
+        [[ -f $_zplug_cache[plugin] ]] && source "$_zplug_cache[plugin]"
+        [[ -f $_zplug_cache[lazy_plugin] ]] && source "$_zplug_cache[lazy_plugin]"
+        [[ -f $_zplug_cache[theme] ]] && source "$_zplug_cache[theme]"
+        [[ -f $_zplug_cache[command] ]] && source "$_zplug_cache[command]"
 
         # Plugins with defer-level set
-        source "$_zplug_cache[defer_1_plugin]"
+        [[ -f $_zplug_cache[defer_1_plugin] ]] && source "$_zplug_cache[defer_1_plugin]"
         compinit -d "$ZPLUG_HOME/zcompdump"
         if (( $_zplug_boolean_true[(I)$is_verbose] )); then
             __zplug::io::print::f \
                 --zplug "$fg[yellow]Run compinit$reset_color\n"
         fi
-        source "$_zplug_cache[defer_2_plugin]"
-        source "$_zplug_cache[defer_3_plugin]"
+        [[ -f $_zplug_cache[defer_2_plugin] ]] && source "$_zplug_cache[defer_2_plugin]"
+        [[ -f $_zplug_cache[defer_3_plugin] ]] && source "$_zplug_cache[defer_3_plugin]"
     }
 
     if [[ -s $_zplug_load_log[failure] ]]; then

--- a/test/commands/load.t
+++ b/test/commands/load.t
@@ -61,6 +61,20 @@ T_SUB "load creates command symlink for as:command" ((
     t_ok $? "command symlink exists in ZPLUG_BIN"
 ))
 
+T_SUB "load with no packages emits no errors (#577)" ((
+    zplugs=()
+    # Simulate a fresh install: empty cache dir, nothing registered
+    rm -rf "$ZPLUG_CACHE_DIR"
+    mkdir -p "$ZPLUG_CACHE_DIR"
+
+    local err
+    err="$(ZPLUG_USE_CACHE=true zplug load 2>&1)"
+    t_is "$err" "" "no error output with cache enabled"
+
+    err="$(ZPLUG_USE_CACHE=false zplug load 2>&1)"
+    t_is "$err" "" "no error output with cache disabled"
+))
+
 T_SUB "load adds fpath for plugin with completions" ((
     zplugs=()
     local dir="$ZPLUG_REPOS/test-user/comp-test"


### PR DESCRIPTION
Fixes #577.

A fresh install with no packages registered prints eight errors on every new shell:

```
__zplug::core::load::from_cache:12: no such file or directory: /opt/homebrew/opt/zplug/cache/fpath.zsh
__zplug::core::load::from_cache:source:17: no such file or directory: /opt/homebrew/opt/zplug/cache/plugin.zsh
...
```

Root cause: `init.zsh` creates an empty `$ZPLUG_CACHE_DIR`, and with an empty `zplugs` the `cache::diff` comparison is empty-vs-empty, so it returns "same" without ever running the `set_file` loop that creates the cache files. `from_cache` then sources all eight files unconditionally. The `ZPLUG_USE_CACHE=false` path hits the same thing since `cache::diff` returns before `set_file` there too, which is why disabling the cache didn't help anyone in the issue thread.

This also explains the workarounds people found there: registering one plugin makes the interface differ (so `set_file` runs), and `zplug clear` removes the cache dir (so the `-d` check fails and `set_file` runs).

The fix checks each cache file exists before sourcing it. I put the guards in `from_cache` rather than in `cache::diff` because only this spot also covers the cache-disabled path, where files for empty categories legitimately never get created.

Added a regression test to `test/commands/load.t` that runs `zplug load` with an empty `zplugs`, cache on and off. It fails without the fix and passes with it; `make test` passes (57/57).